### PR TITLE
Fixed error while trying to unpair bridge

### DIFF
--- a/Sources/HAP/Server/Storage.swift
+++ b/Sources/HAP/Server/Storage.swift
@@ -64,7 +64,7 @@ public class FileStorage: Storage {
             do {
                 if let newValue = newValue {
                     try newValue.write(to: entityPath)
-                } else {
+                } else if FileManager.default.fileExists(atPath: entityPath.absoluteString) {
                     try FileManager.default.removeItem(at: entityPath)
                 }
             } catch {


### PR DESCRIPTION
When device is connected and already paired with HAP Server, and then you want to unpair with it, error is caused because server is trying to delete pairing file which doesn't exists. I think it would be nice to check if file exist before deleting it. Just small bug. 

`[hap.pairings|DEBUG] Updating pairings data: [HAP.PairTag.sequence: 1 bytes, HAP.PairTag.pairingMethod: 1 bytes, HAP.PairTag.username: 36 bytes], method: delete
fatal error: Could not write to storage: Error Domain=NSCocoaErrorDomain Code=4 "“pairing.41363535423736462d453033382d353836352d394337302d394644413436444443383144” couldn’t be removed." UserInfo={NSFilePath=/Users/%%%%/Documents/iOS_projects/HAP/db/pairing.41363535423736462d453033382d353836352d394337302d394644413436444443383144, NSUserStringVariant=(
    Remove
), NSUnderlyingError=0x7fb54ec24020 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}: file /Users/%%%%%/Documents/iOS_projects/HAP/Sources/HAP/Server/Storage.swift, line 71`