### PR TITLE
iid of info should always be 1

### DIFF
--- a/Sources/HAP/Server/Device.swift
+++ b/Sources/HAP/Server/Device.swift
@@ -81,7 +81,7 @@ public class Device {
             accessory.device = self
             accessory.aid = idGenerator.next()!
             for service in accessory.services {
-                service.iid = idGenerator.next()!
+                service.iid = service is Service.Info ? 1 : idGenerator.next()!
                 for characteristic in service.characteristics {
                     characteristic.iid = idGenerator.next()!
                 }


### PR DESCRIPTION
HAP Spec 2.6.1.2 Service and Characteristic Instance IDs

> The Accessory Information service must have a service instance ID of 1.

This seems to be critical. The Home app refuses to connect otherwise