### PR TITLE
Allow subclasses of predefined accessories to add Services

### DIFF
--- a/Sources/HAP/Base/Accessory.swift
+++ b/Sources/HAP/Base/Accessory.swift
@@ -26,19 +26,26 @@ open class Accessory {
     internal var aid: InstanceID = 0
     public let type: AccessoryType
     public let info: Service.Info
-    internal let services: [Service]
-
+    internal var services: [Service]
+    
+    // TODO: SwiftFoundation in Swift 4.0 cannot encode/decode UInt64,
+    // which is the data-type we wanted to use here. We can change it back
+    // to UInt64 once the following commit has made it into a release:
+    // https://github.com/apple/swift-corelibs-foundation/commit/64b67c91479390776c43a96bd31e4e85f106d5e1
+    private var idGenerator = (1...InstanceID.max).makeIterator()
+    
+    
     public init(info: Service.Info, type: AccessoryType, services: [Service]) {
         self.type = type
         self.info = info
         self.services = [info] + services
-
+        
         // 5.3.1 Accessory Objects
         // Array of Service objects. Must not be empty. The maximum number of
         // services must not exceed 100.
         precondition((1...100).contains(self.services.count),
                      "Number of services should be 1...100")
-
+        
         // 2.6.1.2 Service and Characteristic Instance IDs
         // Service and Characteristic instance IDs, "iid", are assigned from
         // the same number pool that is unique within each Accessory object.
@@ -53,11 +60,6 @@ open class Accessory {
         // services and characteristics that were removed in the firmware
         // update.
         //
-        // TODO: SwiftFoundation in Swift 4.0 cannot encode/decode UInt64,
-        // which is the data-type we wanted to use here. We can change it back
-        // to UInt64 once the following commit has made it into a release:
-        // https://github.com/apple/swift-corelibs-foundation/commit/64b67c91479390776c43a96bd31e4e85f106d5e1
-        var idGenerator = (1...InstanceID.max).makeIterator()
         for service in self.services {
             service.iid = idGenerator.next()!
             service.accessory = self
@@ -66,6 +68,45 @@ open class Accessory {
                 characteristic.iid = idGenerator.next()!
             }
         }
+    }
+    
+    
+    public func addServices(_ newServices: [Service]) -> Void {
+        
+        precondition(device == nil, "Services must be added before accessory is associated with a device")
+        
+        // 5.3.1 Accessory Objects
+        // Array of Service objects. Must not be empty. The maximum number of
+        // services must not exceed 100.
+        precondition((1...100).contains(self.services.count+newServices.count),
+                     "Number of services should be 1...100")
+        
+        // 2.6.1.2 Service and Characteristic Instance IDs
+        // Service and Characteristic instance IDs, "iid", are assigned from
+        // the same number pool that is unique within each Accessory object.
+        // For example, if the first Service object has an instance ID of "1"
+        // then no other Service or Characteristic objects can have an instance
+        // ID of "1" within the parent Accessory object. The Accessory
+        // Information service must have a service instance ID of 1.
+        //
+        // After a firmware update services and characteristics types that
+        // remain unchanged must retain their previous instance ids, newly
+        // added services and characteristics must not reuse instance ids from
+        // services and characteristics that were removed in the firmware
+        // update.
+        //
+        
+        for service in newServices {
+            service.iid = idGenerator.next()!
+            service.accessory = self
+            for characteristic in service.characteristics {
+                characteristic.service = service
+                characteristic.iid = idGenerator.next()!
+            }
+            self.services.append(service)
+        }
+        
+        
     }
 }
 
@@ -77,3 +118,4 @@ extension Accessory: JSONSerializable {
         ]
     }
 }
+


### PR DESCRIPTION
Add an addServices() method to permit subclasses of predefined accessories to add additional services