### PR TITLE
Pairing observer

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -38,6 +38,7 @@ identifier_name:
     - ev
     - ok
     - on
+    - to
     - x
     - y
     - SESSION_KEY

--- a/Sources/HAP/Base/Characteristic.swift
+++ b/Sources/HAP/Base/Characteristic.swift
@@ -82,10 +82,9 @@ public class GenericCharacteristic<T: CharacteristicValueType>: Characteristic, 
                 }
             }
             _value = newValue
-            guard let device = service?.accessory?.device else {
-                return
+            if let device = service?.accessory?.device {
+                device.notifyListeners(of: self)
             }
-            device.notifyListeners(of: self)
         }
     }
 

--- a/Sources/HAP/Controllers/PairVerifyController.swift
+++ b/Sources/HAP/Controllers/PairVerifyController.swift
@@ -61,8 +61,8 @@ class PairVerifyController {
         let signature = try Ed25519.sign(privateKey: device.privateKey, message: material)
 
         let resultInner: PairTagTLV8 = [
-            .identifier: device.identifier.data(using: .utf8)!,
-            .signature: signature
+            (.identifier, device.identifier.data(using: .utf8)!),
+            (.signature, signature)
         ]
         logger.debug("startRequest result: \(resultInner)")
 
@@ -79,9 +79,9 @@ class PairVerifyController {
         }
 
         let resultOuter: PairTagTLV8 = [
-            .state: Data(bytes: [PairVerifyStep.startResponse.rawValue]),
-            .publicKey: session.publicKey,
-            .encryptedData: encryptedResultInner
+            (.state, Data(bytes: [PairVerifyStep.startResponse.rawValue])),
+            (.publicKey, session.publicKey),
+            (.encryptedData, encryptedResultInner)
         ]
         logger.debug("startRequest encrypted result: \(resultOuter)")
         return (resultOuter, session)
@@ -129,7 +129,7 @@ class PairVerifyController {
 
         logger.info("Pair verify completed")
         let result: PairTagTLV8 = [
-            .state: Data(bytes: [PairVerifyStep.finishResponse.rawValue])
+            (.state, Data(bytes: [PairVerifyStep.finishResponse.rawValue]))
         ]
         return (result, pairing)
     }

--- a/Sources/HAP/Controllers/PairingsController.swift
+++ b/Sources/HAP/Controllers/PairingsController.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+class PairingsController {
+    let device: Device
+    public init(device: Device) {
+        self.device = device
+    }
+
+    func listPairings() -> PairTagTLV8 {
+        let pairings = device.configuration.pairings.values
+            .map { pairing -> PairTagTLV8 in
+                [
+                    (.identifier, pairing.identifier),
+                    (.publicKey, pairing.publicKey),
+                    (.permissions, Data(bytes: [pairing.role.rawValue]))
+                ]
+            }
+            .joined(separator: [(.state, Data(bytes: [PairStep.response.rawValue]))])
+            .flatMap { $0 }
+        return [(.state, Data(bytes: [PairStep.response.rawValue]))] + pairings
+    }
+}

--- a/Sources/HAP/Endpoints/pairSetup().swift
+++ b/Sources/HAP/Endpoints/pairSetup().swift
@@ -62,11 +62,12 @@ func pairSetup(device: Device) -> Application {
                 response = try controller.keyExchangeRequest(data, session)
             // Unknown state - return error and abort
             default:
-                response = try controller.unknownRequest(data)
+                throw PairSetupController.Error.invalidParameters
             }
         } catch {
             logger.warning(error)
             connection.context[SESSION_KEY] = nil
+            try? device.changePairingState(.notPaired)
             switch error {
             case PairSetupController.Error.invalidParameters:
                 response = [

--- a/Sources/HAP/Endpoints/pairings().swift
+++ b/Sources/HAP/Endpoints/pairings().swift
@@ -22,8 +22,8 @@ func pairings(device: Device) -> Application {
         guard connection.pairing?.role == .admin else {
             logger.warning("Permission denied (non-admin) to update pairing data: \(data), method: \(method)")
             let result: PairTagTLV8 = [
-                .state: Data(bytes: [PairStep.response.rawValue]),
-                .error: Data(bytes: [PairError.authenticationFailed.rawValue])
+                (.state, Data(bytes: [PairStep.response.rawValue])),
+                (.error, Data(bytes: [PairError.authenticationFailed.rawValue]))
             ]
             return Response(status: .ok, data: encode(result), mimeType: "application/pairing+tlv8")
         }
@@ -43,16 +43,31 @@ func pairings(device: Device) -> Application {
             device.remove(pairingWithIdentifier: username)
             logger.info("Removed pairing for \(String(data: username, encoding: .utf8)!)")
         case .listPairings:
-            // TODO: implement
-            logger.warning("Received List Pairings command, but that's not implemented")
-            return .badRequest
+            logger.debug("Listing parings")
+            var pairings = device.configuration.pairings.makeIterator()
+            let firstPairing = pairings.next()!.value
+            var results: PairTagTLV8 = [
+                (.state, Data(bytes: [PairStep.response.rawValue])),
+                (.identifier, firstPairing.identifier),
+                (.publicKey, firstPairing.publicKey),
+                (.permissions, Data(bytes: [firstPairing.role.rawValue]))
+            ]
+            logger.debug("Pairing 1 ID: \(firstPairing.identifier) \(firstPairing.role)")
+            while let p = pairings.next()?.value {
+                results.append((.separator, Data()))
+                results.append((.identifier, p.identifier))
+                results.append((.publicKey, p.publicKey))
+                results.append((.permissions, Data(bytes: [p.role.rawValue])))
+                logger.debug("Pairing n ID: \(p.identifier) \(p.role)")
+            }
+            return Response(status: .ok, data: encode(results), mimeType: "application/pairing+tlv8")
         default:
             logger.info("Unhandled PairingMethod request: \(method)")
             return .badRequest
         }
 
         let result: PairTagTLV8 = [
-            .state: Data(bytes: [PairStep.response.rawValue])
+            (.state, Data(bytes: [PairStep.response.rawValue]))
         ]
         return Response(status: .ok, data: encode(result), mimeType: "application/pairing+tlv8")
     }

--- a/Sources/HAP/Endpoints/pairings().swift
+++ b/Sources/HAP/Endpoints/pairings().swift
@@ -4,6 +4,8 @@ import func Evergreen.getLogger
 fileprivate let logger = getLogger("hap.endpoints.pairings")
 
 func pairings(device: Device) -> Application {
+    let controller = PairingsController(device: device)
+
     return { connection, request in
         var body = Data()
         guard request.method == "POST" else {
@@ -13,8 +15,7 @@ func pairings(device: Device) -> Application {
             (try? request.readAllData(into: &body)) != nil,
             let data: PairTagTLV8 = try? decode(body),
             data[.state]?[0] == PairStep.request.rawValue,
-            let method = data[.pairingMethod].flatMap({ PairingMethod(rawValue: $0[0]) }),
-            let username = data[.identifier]
+            let method = data[.pairingMethod].flatMap({ PairingMethod(rawValue: $0[0]) })
             else {
                 return .badRequest
         }
@@ -32,7 +33,8 @@ func pairings(device: Device) -> Application {
 
         switch method {
         case .addPairing:
-            guard let publicKey = data[.publicKey],
+            guard let username = data[.identifier],
+                let publicKey = data[.publicKey],
                 let permissions = data[.permissions]?.first,
                 let role = Pairing.Role(rawValue: permissions) else {
                     return .badRequest
@@ -40,22 +42,15 @@ func pairings(device: Device) -> Application {
             device.add(pairing: Pairing(identifier: username, publicKey: publicKey, role: role))
             logger.info("Added \(role) pairing for \(String(data: username, encoding: .utf8)!)")
         case .removePairing:
+            guard let username = data[.identifier] else {
+                return .badRequest
+            }
             device.remove(pairingWithIdentifier: username)
             logger.info("Removed pairing for \(String(data: username, encoding: .utf8)!)")
         case .listPairings:
             logger.debug("Listing parings")
-            let pairings = device.configuration.pairings.values
-                .map { pairing -> PairTagTLV8 in
-                    [
-                        (.identifier, pairing.identifier),
-                        (.publicKey, pairing.publicKey),
-                        (.permissions, Data(bytes: [pairing.role.rawValue]))
-                    ]
-                }
-                .joined(separator: [(.state, Data(bytes: [PairStep.response.rawValue]))])
-                .flatMap { $0 }
-            let results: PairTagTLV8 = [(.state, Data(bytes: [PairStep.response.rawValue]))] + pairings
-            return Response(status: .ok, data: encode(results), mimeType: "application/pairing+tlv8")
+            let result = controller.listPairings()
+            return Response(status: .ok, data: encode(result), mimeType: "application/pairing+tlv8")
         default:
             logger.info("Unhandled PairingMethod request: \(method)")
             return .badRequest

--- a/Sources/HAP/Server/Device.swift
+++ b/Sources/HAP/Server/Device.swift
@@ -5,6 +5,16 @@ import func Evergreen.getLogger
 
 fileprivate let logger = getLogger("hap.device")
 
+// MARK: Pairing State
+
+public enum PairingState {
+    case notPaired
+    case pairing
+    case paired
+}
+
+// MARK: Device class
+
 // swiftlint:disable:next type_body_length
 public class Device {
     internal(set) public var name: String {
@@ -25,6 +35,15 @@ public class Device {
     let storage: Storage
 
     weak var server: Server?
+
+    public var onPairingStateChange: [(PairingState, PairingState) -> Void] = []
+
+    public private(set) var state = PairingState.notPaired {
+        didSet {
+            logger.info("State change from: \(oldValue) to \(self.state)")
+            _ = onPairingStateChange.map { $0(oldValue, state) }
+        }
+    }
 
     private(set) var characteristicEventListeners: [Box<Characteristic>: WeakObjectSet<Server.Connection>]
     private(set) var configuration: Configuration
@@ -119,6 +138,9 @@ public class Device {
         case .random:
             break
         }
+
+        // restore state from configuration
+        state = configuration.pairings.isEmpty ? .notPaired : .paired
 
         characteristicEventListeners = [:]
 
@@ -267,27 +289,38 @@ public class Device {
             .isEmpty
     }
 
+    // MARK: - Pairing
+
+    func changePairingState(_ newState: PairingState) {
+        switch (state, newState) {
+        case (.pairing, .notPaired), (.notPaired, .pairing):
+            state = newState
+        case (.pairing, .paired), (.paired, .notPaired):
+            state = newState
+            // Update the Bonjour TXT record
+            notifyConfigurationChange()
+        default:
+            fatalError("Invalid state tranistion: \(state) -> \(newState)")
+        }
+    }
+
     public var isPaired: Bool {
-        return !configuration.pairings.isEmpty
+        return state == .paired
     }
 
     // Add the pairing to the internal DB and notify the change
     // to update the Bonjour broadcast
     func add(pairing: Pairing) {
-        if !isPaired {
-            defer {
-                // Update the Bonjour TXT record
-                notifyConfigurationChange()
-            }
-        }
         configuration.pairings[pairing.identifier] = pairing
         persistConfig()
+        if state == .pairing {
+            changePairingState(.paired)
+        }
     }
 
     // Remove the pairing in the internal DB and notify the change
     // to update the Bonjour broadcast
     func remove(pairingWithIdentifier identifier: PairingIdentifier) {
-        let wasPaired = isPaired
         configuration.pairings[identifier] = nil
         // If the last remaining admin controller pairing is removed, all
         // pairings on the accessory must be removed.
@@ -296,15 +329,16 @@ public class Device {
             configuration.pairings = [:]
         }
         persistConfig()
-        if wasPaired && !isPaired {
-            // Update the Bonjour TXT record
-            notifyConfigurationChange()
+        if state == .paired {
+            changePairingState(.notPaired)
         }
     }
 
     func get(pairingWithIdentifier identifier: PairingIdentifier) -> Pairing? {
         return configuration.pairings[identifier]
     }
+
+    // MARK: - Characteristic listeners
 
     // Add an object which would be notified of changes to Characterisics
     func add(characteristic: Characteristic,
@@ -360,6 +394,8 @@ public class Device {
                                  ofAccessory: accessory,
                                  didChangeValue: newValue)
     }
+
+    // MARK: - QR code pairing
 
     // Return a URI which can be displayed as a QR code for quick setup
     // The URI is an encoded form of the setup code and the accessory type, followed by the setup key

--- a/Sources/HAP/Server/Device.swift
+++ b/Sources/HAP/Server/Device.swift
@@ -36,12 +36,10 @@ public class Device {
 
     weak var server: Server?
 
-    public var onPairingStateChange: [(PairingState, PairingState) -> Void] = []
-
     public private(set) var state = PairingState.notPaired {
         didSet {
             logger.info("State change from: \(oldValue) to \(self.state)")
-            _ = onPairingStateChange.map { $0(oldValue, state) }
+            delegate?.didChangePairingState(from: oldValue, to: state)
         }
     }
 

--- a/Sources/HAP/Server/DeviceDelegate.swift
+++ b/Sources/HAP/Server/DeviceDelegate.swift
@@ -47,6 +47,10 @@ public protocol DeviceDelegate: class {
     /// - Parameter accessory: accessory to be identified
     func didRequestIdentificationOf(_ accessory: Accessory)
 
+    /// Tells the delegate that the Device PairingState has changed.
+    ///
+    func didChangePairingState(from: PairingState, to: PairingState)
+
     /// Tells the delegate that the value of a characteristic has changed.
     ///
     /// - Parameters:
@@ -76,6 +80,8 @@ public extension DeviceDelegate {
     func didRequestIdentification() { }
 
     func didRequestIdentificationOf(_ accessory: Accessory) { }
+
+    func didChangePairingState(from: PairingState, to: PairingState) { }
 
     func characteristic<T>(
         _ characteristic: GenericCharacteristic<T>,

--- a/Sources/HAP/Server/Pairing.swift
+++ b/Sources/HAP/Server/Pairing.swift
@@ -16,5 +16,5 @@ internal struct Pairing: Codable {
     // iOS Device's Curve25519 public key
     let publicKey: PublicKey
 
-    let role: Role
+    var role: Role
 }

--- a/Sources/HAP/Utils/TLV8.swift
+++ b/Sources/HAP/Utils/TLV8.swift
@@ -8,6 +8,27 @@ extension Array where Element == PairTagTLV8Tuple {
         return self.first(where: { $0.0 == index })?.1
     }
 
+    var pairStep: PairStep? {
+        return self
+            .first(where: { $0.0 == PairTag.state })?.1
+            .first
+            .flatMap({ PairStep(rawValue: $0) })
+    }
+
+    var pairSetupStep: PairSetupStep? {
+        return self
+            .first(where: { $0.0 == PairTag.state })?.1
+            .first
+            .flatMap({ PairSetupStep(rawValue: $0) })
+    }
+
+    var error: PairError? {
+        return self
+            .first(where: { $0.0 == PairTag.error })?.1
+            .first
+            .flatMap({ PairError(rawValue: $0) })
+    }
+
     static func == (lhs: [PairTagTLV8Tuple], rhs: [PairTagTLV8Tuple]) -> Bool {
         return lhs.elementsEqual(rhs, by: ==)
     }

--- a/Sources/HAP/Utils/TLV8.swift
+++ b/Sources/HAP/Utils/TLV8.swift
@@ -13,6 +13,12 @@ extension Array where Element == PairTagTLV8Tuple {
     }
 }
 
+// Requires Swift 4.1 -- conditional conformance.
+//extension Array: ExpressibleByDictionaryLiteral where Element == PairTagTLV8Tuple {
+//}
+//extension Array: Equatable where Element == PairTagTLV8Tuple {
+//}
+
 enum TLV8Error: Swift.Error {
     case unknownKey(UInt8)
     case decodeError

--- a/Sources/HAP/Utils/TLV8.swift
+++ b/Sources/HAP/Utils/TLV8.swift
@@ -9,14 +9,7 @@ extension Array where Element == PairTagTLV8Tuple {
     }
 
     static func == (lhs: [PairTagTLV8Tuple], rhs: [PairTagTLV8Tuple]) -> Bool {
-
-        if lhs.count != rhs.count {
-            return false
-        }
-        for i in 0..<lhs.count where lhs[i] != rhs[i] {
-            return false
-        }
-        return true
+        return lhs.elementsEqual(rhs, by: ==)
     }
 }
 

--- a/Tests/HAPTests/AccessoriesTests.swift
+++ b/Tests/HAPTests/AccessoriesTests.swift
@@ -3,6 +3,13 @@
 import XCTest
 
 class AccessoriesTests: XCTestCase {
+    static var allTests: [(String, (AccessoriesTests) -> () throws -> Void)] {
+        return [
+            ("testSerialize", testSerialize),
+            ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests)
+        ]
+    }
+
     func testSerialize() {
         serialize(Accessory.Door(info: .init(name: "Door", serialNumber: "00021")))
         serialize(Accessory.Fan(info: .init(name: "Fan", serialNumber: "00022")))
@@ -16,6 +23,19 @@ class AccessoriesTests: XCTestCase {
         serialize(Accessory.Thermostat(info: .init(name: "Thermostat", serialNumber: "00030")))
         serialize(Accessory.Window(info: .init(name: "Window", serialNumber: "00031")))
         serialize(Accessory.WindowCovering(info: .init(name: "WindowCovering", serialNumber: "00032")))
+    }
+
+    // from: https://oleb.net/blog/2017/03/keeping-xctest-in-sync/#appendix-code-generation-with-sourcery
+    func testLinuxTestSuiteIncludesAllTests() {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+            let thisClass = type(of: self)
+            let linuxCount = thisClass.allTests.count
+            let darwinCount = Int(thisClass
+                .defaultTestSuite.testCaseCount)
+            XCTAssertEqual(linuxCount,
+                           darwinCount,
+                           "\(darwinCount - linuxCount) tests are missing from allTests")
+        #endif
     }
 }
 

--- a/Tests/HAPTests/DeviceTests.swift
+++ b/Tests/HAPTests/DeviceTests.swift
@@ -4,6 +4,13 @@ import Foundation
 import XCTest
 
 class DeviceTests: XCTestCase {
+    static var allTests: [(String, (DeviceTests) -> () throws -> Void)] {
+        return [
+            ("testInstanceIdentifiers", testInstanceIdentifiers),
+            ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests)
+        ]
+    }
+
     func testInstanceIdentifiers() {
         // no bridge -- 1 accessory
         do {
@@ -55,5 +62,18 @@ class DeviceTests: XCTestCase {
             XCTAssertEqual(characteristics.map({ $0.iid }),
                            [2, 3, 4, 5, 6, 7, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12])
         }
+    }
+
+    // from: https://oleb.net/blog/2017/03/keeping-xctest-in-sync/#appendix-code-generation-with-sourcery
+    func testLinuxTestSuiteIncludesAllTests() {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+            let thisClass = type(of: self)
+            let linuxCount = thisClass.allTests.count
+            let darwinCount = Int(thisClass
+                .defaultTestSuite.testCaseCount)
+            XCTAssertEqual(linuxCount,
+                           darwinCount,
+                           "\(darwinCount - linuxCount) tests are missing from allTests")
+        #endif
     }
 }

--- a/Tests/HAPTests/EndpointTests.swift
+++ b/Tests/HAPTests/EndpointTests.swift
@@ -824,7 +824,7 @@ class EndpointTests: XCTestCase {
 
             if let firstEventTimestamp = firstEventTimestamp, let secondEventTimestamp = secondEventTimestamp {
                 let delay = secondEventTimestamp.timeIntervalSince(firstEventTimestamp)
-                XCTAssert(delay >= 1, "received event in \(delay) seconds of previous event, events should be sent at a interval of 1 seconds or more")
+                XCTAssert(delay >= 0.99, "received event in \(delay) seconds of previous event, events should be sent at a interval of 1 seconds or more")
             }
         }
     }

--- a/Tests/HAPTests/PairSetupControllerTests.swift
+++ b/Tests/HAPTests/PairSetupControllerTests.swift
@@ -38,7 +38,7 @@ class PairSetupControllerTests: XCTestCase {
             let response = try! controller.startRequest([
                 (.pairingMethod, Data(bytes: [PairingMethod.default.rawValue]))
             ], session)
-            XCTAssertEqual(response[.state]?.first, PairSetupStep.startResponse.rawValue)
+            XCTAssertEqual(response.pairSetupStep, PairSetupStep.startResponse)
             XCTAssertEqual(response[.publicKey], session.server.publicKey)
             XCTAssertEqual(response[.salt], salt)
             clientKeyProof = try! client.processChallenge(salt: response[.salt]!,
@@ -51,7 +51,7 @@ class PairSetupControllerTests: XCTestCase {
                                                           (.proof, clientKeyProof)],
                                                          session)
             XCTAssertNotNil(response)
-            XCTAssertEqual(response![.state]?.first, PairSetupStep.verifyResponse.rawValue)
+            XCTAssertEqual(response?.pairSetupStep, PairSetupStep.verifyResponse)
 
             // Server -> Client: [keyProof]
             let serverKeyProof = response![.proof]!

--- a/Tests/HAPTests/PairSetupControllerTests.swift
+++ b/Tests/HAPTests/PairSetupControllerTests.swift
@@ -47,17 +47,15 @@ class PairSetupControllerTests: XCTestCase {
 
         do {
             // Client -> Server: [publicKey, keyProof]
-            let response = try controller.verifyRequest([(.publicKey, client.publicKey),
-                                                         (.proof, clientKeyProof)],
-                                                        session)
+            let response = try! controller.verifyRequest([(.publicKey, client.publicKey),
+                                                          (.proof, clientKeyProof)],
+                                                         session)
             XCTAssertNotNil(response)
             XCTAssertEqual(response![.state]?.first, PairSetupStep.verifyResponse.rawValue)
 
             // Server -> Client: [keyProof]
             let serverKeyProof = response![.proof]!
             try! client.verifySession(keyProof: serverKeyProof)
-        } catch {
-            return XCTFail("Unable to verify keys")
         }
 
         do {

--- a/Tests/HAPTests/PairVerifyControllerTests.swift
+++ b/Tests/HAPTests/PairVerifyControllerTests.swift
@@ -35,8 +35,8 @@ class PairVerifyControllerTests: XCTestCase {
         do {
             // Client -> Server: public key
             let request: PairTagTLV8 = [
-                PairTag.state: Data(bytes: [PairVerifyStep.startRequest.rawValue]),
-                PairTag.publicKey: clientPublicKey
+                (.state, Data(bytes: [PairVerifyStep.startRequest.rawValue])),
+                (.publicKey, clientPublicKey)
             ]
             let resultOuter: PairTagTLV8
             do {
@@ -90,8 +90,8 @@ class PairVerifyControllerTests: XCTestCase {
                 return XCTFail("Couldn't sign")
             }
             let requestInner: PairTagTLV8 = [
-                .identifier: username,
-                .signature: signature
+                (.identifier, username),
+                (.signature, signature)
             ]
             guard let cipher = try? ChaCha20Poly1305.encrypt(message: encode(requestInner),
                                                              nonce: "PV-Msg03".data(using: .utf8)!,
@@ -99,7 +99,7 @@ class PairVerifyControllerTests: XCTestCase {
                 return XCTFail("Couldn't encode")
             }
             let resultOuter: PairTagTLV8 = [
-                .encryptedData: cipher
+                (.encryptedData, cipher)
             ]
             do {
                 _ = try controller.finishRequest(resultOuter, session)

--- a/Tests/HAPTests/PairingsEndpointTests.swift
+++ b/Tests/HAPTests/PairingsEndpointTests.swift
@@ -1,0 +1,64 @@
+// swiftlint:disable force_try line_length
+import Foundation
+@testable import HAP
+@testable import KituraNet
+import XCTest
+
+class PairingsEndpointTests: XCTestCase {
+    static var allTests: [(String, (PairingsEndpointTests) -> () throws -> Void)] {
+        return [
+            ("testListPairingsNonAdmin", testListPairingsNonAdmin),
+            ("testListPairingsAdmin", testListPairingsAdmin),
+            ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests)
+        ]
+    }
+
+    var device: Device!
+    var connection: MockConnection!
+    var application: Application!
+    override func setUp() {
+        device = Device(bridgeInfo: .init(name: "Test", serialNumber: "00072B"), setupCode: "123-44-321", storage: MemoryStorage(), accessories: [])
+        connection = MockConnection()
+        connection.pairing = Pairing(identifier: Data(), publicKey: Data(), role: .regularUser)
+        device.add(pairing: connection.pairing!)
+        application = pairings(device: device)
+    }
+
+    func call(_ data: PairTagTLV8) -> (Response, PairTagTLV8?) {
+        let response = application(connection, MockRequest(method: "POST", path: "/pairings", body: encode(data)))
+        return (response, try! decode(response.body!))
+    }
+
+    func testListPairingsNonAdmin() {
+        let request = [
+            (PairTag.state, Data(bytes: [PairStep.request.rawValue])),
+            (PairTag.pairingMethod, Data(bytes: [PairingMethod.listPairings.rawValue]))
+        ]
+        let (_, responseBody) = call(request)
+        XCTAssertEqual(responseBody?.error, PairError.authenticationFailed)
+    }
+
+    func testListPairingsAdmin() {
+        connection.pairing?.role = .admin
+        let request = [
+            (PairTag.state, Data(bytes: [PairStep.request.rawValue])),
+            (PairTag.pairingMethod, Data(bytes: [PairingMethod.listPairings.rawValue]))
+        ]
+        let (_, responseBody) = call(request)
+        XCTAssertEqual(responseBody?.pairStep, PairStep.response)
+        XCTAssertEqual(responseBody?.count, 4) // state, identifier, publicKey, permissions
+    }
+
+    // from: https://oleb.net/blog/2017/03/keeping-xctest-in-sync/#appendix-code-generation-with-sourcery
+    func testLinuxTestSuiteIncludesAllTests() {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+            let thisClass = type(of: self)
+            let linuxCount = thisClass.allTests.count
+            let darwinCount = Int(thisClass
+                .defaultTestSuite.testCaseCount)
+            XCTAssertEqual(linuxCount,
+                           darwinCount,
+                           "\(darwinCount - linuxCount) tests are missing from allTests")
+        #endif
+    }
+}

--- a/Tests/HAPTests/TLV8Tests.swift
+++ b/Tests/HAPTests/TLV8Tests.swift
@@ -15,11 +15,11 @@ class TLV8Tests: XCTestCase {
     func test() {
         let publicKey = Data(repeating: 0, count: 256) + Data(repeating: 1, count: 256) + Data(repeating: 2, count: 256)
         let original: PairTagTLV8 = [
-            .publicKey: publicKey
+            (.publicKey, publicKey)
         ]
         let encoded = encode(original)
         let decoded: PairTagTLV8 = try! decode(encoded)
-        XCTAssertEqual(original, decoded)
+        XCTAssertTrue(original == decoded)
     }
 
     // from: https://oleb.net/blog/2017/03/keeping-xctest-in-sync/#appendix-code-generation-with-sourcery

--- a/Tests/HAPTests/Utils.swift
+++ b/Tests/HAPTests/Utils.swift
@@ -100,7 +100,6 @@ final class MockRequest: ServerRequest {
 
 class MockConnection: HAP.Server.Connection {
     var sideChannelCallback: ((Data) -> Void)?
-
     override func writeOutOfBand(_ data: Data) {
         sideChannelCallback?(data)
     }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,7 +2,10 @@
 import XCTest
 
 XCTMain([
+    testCase(AccessoriesTests.allTests),
+    testCase(DeviceTests.allTests),
     testCase(EndpointTests.allTests),
+    testCase(PairingsEndpointTests.allTests),
     testCase(PairSetupControllerTests.allTests),
     testCase(PairVerifyControllerTests.allTests),
     testCase(TLV8Tests.allTests)


### PR DESCRIPTION
The last commit to HAP/master removed the `onConfigurationChange` callback in `Device`. This was useful for monitoring pairing status by the application calling HAP. 

This pull request proposes to add back a callback mechanism for specifically monitoring pairing status. An enum communicating the pairing stage `PairingEvent` is passed to the callback.