### PR TITLE
Server.Connection fix race condition

### DIFF
--- a/Sources/HAP/Server/Server.swift
+++ b/Sources/HAP/Server/Server.swift
@@ -96,9 +96,6 @@ public class Server: NSObject, NetServiceDelegate {
         queue.async { [unowned self, socket] in
             Connection().listen(socket: socket, application: self.application)
 
-            logger.debug("Closed connection to \(socket.remoteHostname)")
-            socket.close()
-
             self.socketLockQueue.sync { [unowned self, socket] in
                 self.connectedSockets[socket.socketfd] = nil
             }


### PR DESCRIPTION
Writes or socket closure may occur asynchronously on different threads. Race conditions are avoided by performing writes and closure on a private serial queue. Connection().listen() now closes a socket before returning.