### PR TITLE
November fixes

### DIFF
--- a/Sources/HAP/Endpoints/Protocol.swift
+++ b/Sources/HAP/Endpoints/Protocol.swift
@@ -44,6 +44,7 @@ enum Protocol {
         case int(Int)
         case double(Double)
         case string(String)
+        case bool(Bool)
 
         enum DecodeError: Error {
             case unsupportedValueType
@@ -57,6 +58,8 @@ enum Protocol {
                 self = .double(double)
             } else if let string = try? container.decode(String.self) {
                 self = .string(string)
+            } else if let bool = try? container.decode(Bool.self) {
+                self = .bool(bool)
             } else {
                 throw DecodeError.unsupportedValueType
             }
@@ -71,6 +74,8 @@ enum Protocol {
                 try container.encode(double)
             case let .string(string):
                 try container.encode(string)
+            case let .bool(bool):
+                try container.encode(bool)
             }
         }
     }

--- a/Sources/HAP/Endpoints/characteristics().swift
+++ b/Sources/HAP/Endpoints/characteristics().swift
@@ -107,8 +107,8 @@ func characteristics(device: Device) -> Application {
             let byteCount = try? request.readAllData(into: &body)
             logger.debug("PUT data: \(String(bytes: body, encoding: .utf8))")
             guard byteCount != nil,
-                let decoded = try? JSONDecoder().decode(Protocol.CharacteristicContainer.self, from: body) else
-            {
+                let decoded = try? JSONDecoder().decode(Protocol.CharacteristicContainer.self, from: body)
+            else {
                     logger.warning("Could not decode JSON")
                     return .badRequest
             }

--- a/Sources/HAP/Endpoints/characteristics().swift
+++ b/Sources/HAP/Endpoints/characteristics().swift
@@ -104,8 +104,9 @@ func characteristics(device: Device) -> Application {
 
         case "PUT":
             var body = Data()
-            guard
-                (try? request.readAllData(into: &body)) != nil,
+            let byteCount = try? request.readAllData(into: &body)
+            logger.debug("PUT data: \(String(bytes: body, encoding: .utf8))")
+            guard byteCount != nil,
                 let decoded = try? JSONDecoder().decode(Protocol.CharacteristicContainer.self, from: body) else
             {
                     logger.warning("Could not decode JSON")
@@ -148,6 +149,8 @@ func characteristics(device: Device) -> Application {
                             try characteristic.setValue(int, fromConnection: connection)
                         case let .double(double):
                             try characteristic.setValue(double, fromConnection: connection)
+                        case let .bool(bool):
+                            try characteristic.setValue(bool, fromConnection: connection)
                         }
                         status.status = .success
                     } catch {

--- a/Sources/HAP/Server/Configuration.swift
+++ b/Sources/HAP/Server/Configuration.swift
@@ -42,7 +42,7 @@ extension Device {
         // Accessories must increment the config number after a firmware update.
         // This must have a range of 1-4294967295 and wrap to 1 when it overflows.
         // This value must persist across reboots, power cycles, etc.
-        internal var number: UInt32 = 0
+        internal var number: UInt32 = 1
 
         // HAP Specification 2.6.1: Instance IDs
         //

--- a/Sources/HAP/Server/DeviceDelegate.swift
+++ b/Sources/HAP/Server/DeviceDelegate.swift
@@ -51,6 +51,10 @@ public protocol DeviceDelegate: class {
     ///
     func didChangePairingState(from: PairingState, to: PairingState)
 
+    /// Tells the delegate that one or more Accessories were added or removed.
+    ///
+    func didChangeAccessoryList()
+
     /// Tells the delegate that the value of a characteristic has changed.
     ///
     /// - Parameters:
@@ -82,6 +86,8 @@ public extension DeviceDelegate {
     func didRequestIdentificationOf(_ accessory: Accessory) { }
 
     func didChangePairingState(from: PairingState, to: PairingState) { }
+
+    func didChangeAccessoryList() { }
 
     func characteristic<T>(
         _ characteristic: GenericCharacteristic<T>,

--- a/Sources/HAP/Server/Server.swift
+++ b/Sources/HAP/Server/Server.swift
@@ -19,7 +19,25 @@ public class Server: NSObject, NetServiceDelegate {
     let listenSocket: Socket
     let socketLockQueue = DispatchQueue(label: "hap.socketLockQueue")
 
-    var continueRunning = true
+    let continueRunningLock = DispatchSemaphore(value: 1)
+
+    // swiftlint:disable:next identifier_name
+    var _continueRunning = false
+    var continueRunning: Bool {
+        get {
+            continueRunningLock.wait()
+            defer {
+                continueRunningLock.signal()
+            }
+            return _continueRunning
+        }
+        set {
+            continueRunningLock.wait()
+            _continueRunning = newValue
+            continueRunningLock.signal()
+        }
+
+    }
     var connectedSockets = [Int32: Socket]()
 
     public init(device: Device, port: Int = 0) throws {
@@ -51,6 +69,9 @@ public class Server: NSObject, NetServiceDelegate {
     }
 
     public func start() {
+        if #available(OSX 10.12, *) {
+            dispatchPrecondition(condition: .onQueue(.main))
+        }
         // TODO: make sure can only be started if not started
 
         continueRunning = true
@@ -62,27 +83,41 @@ public class Server: NSObject, NetServiceDelegate {
             do {
                 repeat {
                     let newSocket = try self.listenSocket.acceptClientConnection()
-                    logger.info("Accepted connection from \(newSocket.remoteHostname)")
+                    DispatchQueue.main.async {
+                        logger.info("Accepted connection from \(newSocket.remoteHostname)")
+                    }
                     self.addNewConnection(socket: newSocket)
                 } while self.continueRunning
             } catch {
                 logger.error("Could not accept connections for listening socket", error: error)
             }
-            self.stop()
+            self.tearDownConnections()
+            self.listenSocket.close()
         }
     }
 
-    public func stop() {
+    func tearDownConnections() {
         service.stop()
         continueRunning = false
-        listenSocket.close()
 
         socketLockQueue.sync { [unowned self] in
             for socket in self.connectedSockets {
-                socket.value.close()
+                Socket.forceClose(socketfd: socket.key)
             }
             self.connectedSockets = [:]
         }
+
+    }
+
+    public func stop() {
+        if #available(OSX 10.12, *) {
+            dispatchPrecondition(condition: .onQueue(.main))
+        }
+        continueRunning = false
+
+        //listenSocket.close()
+        Socket.forceClose(socketfd: listenSocket.socketfd)
+        //tearDownConnections()
     }
 
     func addNewConnection(socket: Socket) {

--- a/Sources/HAP/Utils/Socket+forceClose.swift
+++ b/Sources/HAP/Utils/Socket+forceClose.swift
@@ -20,6 +20,8 @@ extension Socket {
     // thread by closing the sockets file descriptor using system calls.
     //
     // Assumes socket is being listened to and is connected
+    //
+    // swiftlint:disable:next identifier_name
     static func forceClose(socketfd fd: Int32) {
         #if os(Linux)
         _ = Glibc.shutdown(fd, Int32(SHUT_RDWR))

--- a/Sources/HAP/Utils/Socket+forceClose.swift
+++ b/Sources/HAP/Utils/Socket+forceClose.swift
@@ -1,0 +1,32 @@
+//
+//  Socket+forceClose.swift
+//  HAP
+//
+//  Created by Guy Brooker on 10/10/2018.
+//
+
+import Foundation
+import Socket
+
+#if os(macOS) || os(iOS) || os(tvOS)
+import Darwin
+#elseif os(Linux)
+import Glibc
+#endif
+
+extension Socket {
+
+    // Avoid race conditions in BlueSocket when closing a socket from another
+    // thread by closing the sockets file descriptor using system calls.
+    //
+    // Assumes socket is being listened to and is connected
+    static func forceClose(socketfd fd: Int32) {
+        #if os(Linux)
+        _ = Glibc.shutdown(fd, Int32(SHUT_RDWR))
+        _ = Glibc.close(fd)
+        #else
+        _ = Darwin.shutdown(fd, Int32(SHUT_RDWR))
+        _ = Darwin.close(fd)
+        #endif
+    }
+}


### PR DESCRIPTION
This pull request combines a number of fixes and minor enhancements.
Fixes:
- Fix race condition when calling Evergreen logger from Server queue
- Fix for HomePod (add boolean type to possible Characteristic values). HomePod sends true or false for the "on" characteristic, whereas iPhones send 1 or 0.
- Fix for accessory configuration on restart. Prior to this fix, restarting a bridge incremented the configuration count each time, causing HomeKit to forget room settings.
- Fix for a race condition on the continueRunning flag in Server, and improve support to stop and restart the Server.

Enhancements:
- Add didChangeAccessoryList to DeviceDelegate. Allow a container app to observe changes to accessories (for dynamic accessory discovery)
- Add Device.unpairFromAllControllers(). Removes all pairings