### PR TITLE
Fix unpair, to only change state when no pairings remain

### DIFF
--- a/Sources/HAP/Server/Device.swift
+++ b/Sources/HAP/Server/Device.swift
@@ -317,6 +317,22 @@ public class Device {
         return pairingState == .paired
     }
 
+    // Remove all the pairings made with this Device
+    // Can be used in the event of a stale configuration file
+    public func unpairFromAllControllers() {
+        logger.debug("Before unpair")
+        logger.debug(self.configuration)
+        logger.debug(self.config)
+        server?.stop()
+        let allPairingIdentifiers = configuration.pairings.keys
+        for identifier in allPairingIdentifiers {
+            remove(pairingWithIdentifier: identifier)
+        }
+        logger.debug("After unpair")
+        logger.debug(self.configuration)
+        logger.debug(self.config)
+    }
+
     // Add the pairing to the internal DB and notify the change
     // to update the Bonjour broadcast
     func add(pairing: Pairing) {
@@ -339,7 +355,7 @@ public class Device {
             configuration.pairings = [:]
         }
         persistConfig()
-        if pairingState == .paired {
+        if pairingState == .paired && configuration.pairings.isEmpty {
             // swiftlint:disable:next force_try
             try! changePairingState(.notPaired)
         }

--- a/Sources/HAP/Server/Device.swift
+++ b/Sources/HAP/Server/Device.swift
@@ -319,18 +319,13 @@ public class Device {
 
     // Remove all the pairings made with this Device
     // Can be used in the event of a stale configuration file
-    public func unpairFromAllControllers() {
-        logger.debug("Before unpair")
-        logger.debug(self.configuration)
-        logger.debug(self.config)
+    public func removeAllPairings() {
+        logger.debug("Removing all pairings")
         server?.stop()
         let allPairingIdentifiers = configuration.pairings.keys
         for identifier in allPairingIdentifiers {
             remove(pairingWithIdentifier: identifier)
         }
-        logger.debug("After unpair")
-        logger.debug(self.configuration)
-        logger.debug(self.config)
     }
 
     // Add the pairing to the internal DB and notify the change

--- a/Sources/HAP/Server/Device.swift
+++ b/Sources/HAP/Server/Device.swift
@@ -321,7 +321,6 @@ public class Device {
     // Can be used in the event of a stale configuration file
     public func removeAllPairings() {
         logger.debug("Removing all pairings")
-        server?.stop()
         let allPairingIdentifiers = configuration.pairings.keys
         for identifier in allPairingIdentifiers {
             remove(pairingWithIdentifier: identifier)


### PR DESCRIPTION
Split out from PR #59 

When removing  pairing, only change sate when no more pairings remain.

Add unpairFromAllControllers() function to remove all pairings.
