### PR TITLE
Fix race conditions in Server

### DIFF
--- a/Sources/HAP/Server/Server.swift
+++ b/Sources/HAP/Server/Server.swift
@@ -115,9 +115,12 @@ public class Server: NSObject, NetServiceDelegate {
         }
         continueRunning = false
 
-        //listenSocket.close()
+        // Ideally we would call `.close()` on all open sockets. However
+        // BlueSocket doesn't like us doing that from another thread than
+        // the one that's currently listening. As a workaround, we'll 
+        // force close the file descriptor instead.
+
         Socket.forceClose(socketfd: listenSocket.socketfd)
-        //tearDownConnections()
     }
 
     func addNewConnection(socket: Socket) {

--- a/Sources/HAP/Server/Server.swift
+++ b/Sources/HAP/Server/Server.swift
@@ -19,7 +19,25 @@ public class Server: NSObject, NetServiceDelegate {
     let listenSocket: Socket
     let socketLockQueue = DispatchQueue(label: "hap.socketLockQueue")
 
-    var continueRunning = true
+    let continueRunningLock = DispatchSemaphore(value: 1)
+
+    // swiftlint:disable:next identifier_name
+    var _continueRunning = false
+    var continueRunning: Bool {
+        get {
+            continueRunningLock.wait()
+            defer {
+                continueRunningLock.signal()
+            }
+            return _continueRunning
+        }
+        set {
+            continueRunningLock.wait()
+            _continueRunning = newValue
+            continueRunningLock.signal()
+        }
+
+    }
     var connectedSockets = [Int32: Socket]()
 
     public init(device: Device, port: Int = 0) throws {
@@ -51,6 +69,9 @@ public class Server: NSObject, NetServiceDelegate {
     }
 
     public func start() {
+        if #available(OSX 10.12, *) {
+            dispatchPrecondition(condition: .onQueue(.main))
+        }
         // TODO: make sure can only be started if not started
 
         continueRunning = true
@@ -62,27 +83,41 @@ public class Server: NSObject, NetServiceDelegate {
             do {
                 repeat {
                     let newSocket = try self.listenSocket.acceptClientConnection()
-                    logger.info("Accepted connection from \(newSocket.remoteHostname)")
+                    DispatchQueue.main.async {
+                        logger.info("Accepted connection from \(newSocket.remoteHostname)")
+                    }
                     self.addNewConnection(socket: newSocket)
                 } while self.continueRunning
             } catch {
                 logger.error("Could not accept connections for listening socket", error: error)
             }
-            self.stop()
+            self.tearDownConnections()
+            self.listenSocket.close()
         }
     }
 
-    public func stop() {
+    func tearDownConnections() {
         service.stop()
         continueRunning = false
-        listenSocket.close()
 
         socketLockQueue.sync { [unowned self] in
             for socket in self.connectedSockets {
-                socket.value.close()
+                Socket.forceClose(socketfd: socket.key)
             }
             self.connectedSockets = [:]
         }
+
+    }
+
+    public func stop() {
+        if #available(OSX 10.12, *) {
+            dispatchPrecondition(condition: .onQueue(.main))
+        }
+        continueRunning = false
+
+        //listenSocket.close()
+        Socket.forceClose(socketfd: listenSocket.socketfd)
+        //tearDownConnections()
     }
 
     func addNewConnection(socket: Socket) {

--- a/Sources/HAP/Utils/Socket+forceClose.swift
+++ b/Sources/HAP/Utils/Socket+forceClose.swift
@@ -1,10 +1,3 @@
-//
-//  Socket+forceClose.swift
-//  HAP
-//
-//  Created by Guy Brooker on 10/10/2018.
-//
-
 import Foundation
 import Socket
 

--- a/Sources/HAP/Utils/Socket+forceClose.swift
+++ b/Sources/HAP/Utils/Socket+forceClose.swift
@@ -2,9 +2,9 @@ import Foundation
 import Socket
 
 #if os(macOS) || os(iOS) || os(tvOS)
-import Darwin
+    import Darwin
 #elseif os(Linux)
-import Glibc
+    import Glibc
 #endif
 
 extension Socket {
@@ -17,11 +17,11 @@ extension Socket {
     // swiftlint:disable:next identifier_name
     static func forceClose(socketfd fd: Int32) {
         #if os(Linux)
-        _ = Glibc.shutdown(fd, Int32(SHUT_RDWR))
-        _ = Glibc.close(fd)
+            _ = Glibc.shutdown(fd, Int32(SHUT_RDWR))
+            _ = Glibc.close(fd)
         #else
-        _ = Darwin.shutdown(fd, Int32(SHUT_RDWR))
-        _ = Darwin.close(fd)
+            _ = Darwin.shutdown(fd, Int32(SHUT_RDWR))
+            _ = Darwin.close(fd)
         #endif
     }
 }

--- a/Sources/HAP/Utils/Socket+forceClose.swift
+++ b/Sources/HAP/Utils/Socket+forceClose.swift
@@ -1,0 +1,34 @@
+//
+//  Socket+forceClose.swift
+//  HAP
+//
+//  Created by Guy Brooker on 10/10/2018.
+//
+
+import Foundation
+import Socket
+
+#if os(macOS) || os(iOS) || os(tvOS)
+import Darwin
+#elseif os(Linux)
+import Glibc
+#endif
+
+extension Socket {
+
+    // Avoid race conditions in BlueSocket when closing a socket from another
+    // thread by closing the sockets file descriptor using system calls.
+    //
+    // Assumes socket is being listened to and is connected
+    //
+    // swiftlint:disable:next identifier_name
+    static func forceClose(socketfd fd: Int32) {
+        #if os(Linux)
+        _ = Glibc.shutdown(fd, Int32(SHUT_RDWR))
+        _ = Glibc.close(fd)
+        #else
+        _ = Darwin.shutdown(fd, Int32(SHUT_RDWR))
+        _ = Darwin.close(fd)
+        #endif
+    }
+}


### PR DESCRIPTION
Split out from PR #59 

This PR contains a number of fixes to Server

- The `continueRunning` flag is created on the main queue, but checked on the global queue. The fix makes the flag thread safe by using a `DispatchSemaphore` in the getter and setter
- The logger is created on the main thread, but is also called on the global thread. The fix is execute the log call on the main thread asynchronously
- Calling close on a Socket while it is listening, resulted in a race condition in BlueSocket. The fix extends Socket to add a forceQuit method which shuts down the socket without any internal checks.
- The HAP Server implementation assumes that the `start()` and `stop()` functions are called from the main queue. In the same spirit as the many guard statements throughout HAP, a `dispatchPrecondition` has been added to help developers using the library to ensure they respect this assumption.
-  The public `stop()` was being used both for external shutdown of the server and for internal cleanup. The cleanup part has been moved to `tearDownConnections()`, which is called only from the global queue, after `continueRunning` has been set to `false`. It stops advertising the server on mDNS and it force closes all open sockets. The public `stop()` method is called from the main thread and simply sets the `continueRunning` flag to `false` and force closes the main server socket, causing the previously mentioned cleanup to occur on the global thread.