### PR TITLE
Fix Connection leaks

### DIFF
--- a/Sources/HAP/Server/Device.swift
+++ b/Sources/HAP/Server/Device.swift
@@ -368,7 +368,7 @@ public class Device {
 
             // If the last remaining admin controller pairing is removed, all
             // pairings on the accessory must be removed.
-            if configuration.pairings.values.first(where:{ $0.role == .admin }) == nil {
+            if configuration.pairings.values.first(where: { $0.role == .admin }) == nil {
                 logger.info("Last remaining admin controller pairing is removed, removing all pairings")
                 let allPairingIdentifiers = configuration.pairings.keys
                 for identifier in allPairingIdentifiers {

--- a/Sources/HAP/Server/Server.swift
+++ b/Sources/HAP/Server/Server.swift
@@ -17,7 +17,7 @@ public class Server: NSObject, NetServiceDelegate {
     let service: NetService
 
     let listenSocket: Socket
-    let socketLockQueue = DispatchQueue(label: "hap.socketLockQueue")
+    let connectionsLockQueue = DispatchQueue(label: "hap.connectionsLockQueue")
 
     let continueRunningLock = DispatchSemaphore(value: 1)
 
@@ -38,7 +38,7 @@ public class Server: NSObject, NetServiceDelegate {
         }
 
     }
-    var connectedSockets = [Int32: Socket]()
+    var connections = [Int32: Connection]()
 
     public init(device: Device, port: Int = 0) throws {
         precondition(device.server == nil, "Device already assigned to other Server instance")
@@ -84,7 +84,7 @@ public class Server: NSObject, NetServiceDelegate {
                 repeat {
                     let newSocket = try self.listenSocket.acceptClientConnection()
                     DispatchQueue.main.async {
-                        logger.info("Accepted connection from \(newSocket.remoteHostname)")
+                        logger.info("Accepted connection from \(newSocket.remoteHostname):\(newSocket.remotePort)")
                     }
                     self.addNewConnection(socket: newSocket)
                 } while self.continueRunning
@@ -100,11 +100,11 @@ public class Server: NSObject, NetServiceDelegate {
         service.stop()
         continueRunning = false
 
-        socketLockQueue.sync { [unowned self] in
-            for socket in self.connectedSockets {
-                Socket.forceClose(socketfd: socket.key)
+        connectionsLockQueue.sync { [unowned self] in
+            for (_, connection) in self.connections {
+                connection.tearDown()
             }
-            self.connectedSockets = [:]
+            self.connections = [:]
         }
 
     }
@@ -124,18 +124,33 @@ public class Server: NSObject, NetServiceDelegate {
     }
 
     func addNewConnection(socket: Socket) {
-        socketLockQueue.sync { [unowned self, socket] in
-            self.connectedSockets[socket.socketfd] = socket
-        }
 
         let queue = DispatchQueue.global(qos: .userInteractive)
 
         // Create the run loop work item and dispatch to the default priority global queue...
         queue.async { [unowned self, socket] in
-            Connection().listen(socket: socket, application: self.application)
+            let socketfd = socket.socketfd
+            let connection = Connection(server: self)
 
-            self.socketLockQueue.sync { [unowned self, socket] in
-                self.connectedSockets[socket.socketfd] = nil
+            self.connectionsLockQueue.sync { [unowned self, socket, connection] in
+                self.connections[socket.socketfd] = connection
+            }
+
+            connection.listen(socket: socket, application: self.application)
+
+            self.connectionsLockQueue.sync { [unowned self, socketfd] in
+                self.connections[socketfd] = nil
+            }
+        }
+    }
+
+    func removeConnectionsFor(pairing: Pairing) {
+        connectionsLockQueue.sync { [unowned self] in
+            for (socketfd, connection) in self.connections {
+                if connection.pairing?.identifier == pairing.identifier {
+                    connection.tearDown()
+                    self.connections[socketfd] = nil
+                }
             }
         }
     }

--- a/Sources/HAP/Server/Server.swift
+++ b/Sources/HAP/Server/Server.swift
@@ -146,11 +146,10 @@ public class Server: NSObject, NetServiceDelegate {
 
     func removeConnectionsFor(pairing: Pairing) {
         connectionsLockQueue.sync { [unowned self] in
-            for (socketfd, connection) in self.connections {
-                if connection.pairing?.identifier == pairing.identifier {
+            for (socketfd, connection) in self.connections
+            where connection.pairing?.identifier == pairing.identifier {
                     connection.tearDown()
                     self.connections[socketfd] = nil
-                }
             }
         }
     }


### PR DESCRIPTION
As iOS devices move in and out of a network, connections can become stale but HAP never stops listening, even after the same device comes back at a later date and opens a new connection. 

Without this patch in a moderately busy home, HAP will use all available sockets in its process within a couple of days, such that it is no longer able to open any new network connections. Many stale connections to the same devices continue to be held as zombies, with some entering CLOSE_WAIT state after a few days, and the connections never die. Each `Server.Connection` has its own thread on the global queue, so this problem means HAP steadily leaks memory, threads and sockets. 

This pull request addresses these issues with multiple strategies. 

1. Cleanup when closing a connection: whenever a `Server.Connection` is torn down, it removes itself as a listener for any associated characteristics from the bridge `Device`. 

2. Cleanup when removing a pairing: when a pairing is removed, all `Server.Connections` associated with that pairing will be torn down. 

3. Prune dead connections: Every ten minutes, an empty event is sent to tickle each connection (unless there is or have been very recently active communications). This strategy has been borrowed from nfarina's commit to [KhaosT/HAP-Node-JS](https://github.com/KhaosT/HAP-NodeJS/pull/110#issuecomment-132780821) in August 2015.  If the connection is still alive, iOS (the HAP controller) safely ignores the empty event. But if the connection is dead, the Server.Connection is torn down, as either the socket write or the blocking socket read finally detect the remote device has gone or given up.

After this fix, no zombie connections or threads remain after a device leaves the network, or after a pairing is removed. Running HAP with this PR applied for a week in a home with 20 accessories,  3 users and 6 to 8 controllers moving in and out regularly, shows no more thread, memory or socket leaks.