### PR TITLE
Initial support for iOS 12.2 (beta) Television Accessory

### DIFF
--- a/Sources/HAP/Accessories/Television.swift
+++ b/Sources/HAP/Accessories/Television.swift
@@ -1,4 +1,4 @@
-
+// swiftlint:disable identifier_name
 extension Accessory {
     open class Television: Accessory {
         public let television = Service.Television()
@@ -7,13 +7,16 @@ extension Accessory {
 
         public init(info: Service.Info, inputs: [(String, InputSourceType)], additionalServices: [Service] = []) {
 
-            precondition(inputs.count > 0)
-            var i: UInt32 = 0
+            precondition(!inputs.isEmpty)
+            var idx: UInt32 = 0
             for (name, type) in inputs {
-                sources.append(Service.InputSource(identifier: i, name: name, input: type))
-                i = i+1
+                sources.append(Service.InputSource(identifier: idx, name: name, input: type))
+                idx += 1
             }
-            super.init(info: info, type: .television, services: ([television, speaker] + sources as [Service]) + additionalServices)
+            super.init(info: info,
+                       type: .television,
+                       services: ([television, speaker] + sources as [Service]) + additionalServices)
+
             speaker.name.value = "Speaker"
             television.configuredName.value = info.name.value
             television.activeIdentifier.value = sources[0].identifier.value
@@ -33,7 +36,6 @@ public enum Active: UInt8, CharacteristicValueType {
 
 public typealias ActiveIdentifier = UInt32
 public typealias ConfiguredName = String
-
 
 public enum SleepDiscoveryMode: UInt8, CharacteristicValueType {
     case notDiscoverable = 0
@@ -62,12 +64,12 @@ public enum PictureMode: UInt16, CharacteristicValueType {
     case game = 5
     case computer = 6
     case custom = 7
-    case _other8 = 8
-    case _other9 = 9
-    case _other10 = 10
-    case _other11 = 11
-    case _other12 = 12
-    case _other13 = 13
+//    case _other8 = 8
+//    case _other9 = 9
+//    case _other10 = 10
+//    case _other11 = 11
+//    case _other12 = 12
+//    case _other13 = 13
 }
 
 public enum PowerModeSelection: UInt8, CharacteristicValueType {
@@ -89,7 +91,7 @@ public enum RemoteKey: UInt8, CharacteristicValueType {
     case exit = 10
     case playPause = 11
     case information = 15
-    case _other = 16
+//    case _other = 16
 }
 
 public enum InputSourceType: UInt8, CharacteristicValueType {
@@ -145,7 +147,6 @@ public enum IsConfigured: UInt8, CharacteristicValueType {
     case configured = 1
 }
 
-
 extension Service {
     open class Television: Service {
         public let active = GenericCharacteristic<Active>(
@@ -163,10 +164,8 @@ extension Service {
             value: .alwaysDiscoverable,
             permissions: [.read, .events])
 
-
         // Optional Characteristics
 
-        
         public let brightness = GenericCharacteristic<Brightness>(
             type: .brightness,
             value: 100,
@@ -207,12 +206,13 @@ extension Service {
             minValue: 0)
 
         public init() {
-            super.init(type: .television, characteristics: [active, activeIdentifier, configuredName, sleepDiscoveryMode, powerModeSelection, remoteKey])
+            super.init(type: .television,
+                       characteristics: [active, activeIdentifier, configuredName,
+                                         sleepDiscoveryMode, powerModeSelection, remoteKey])
             self.primary = true
         }
     }
 }
-
 
 extension Service {
     open class InputSource: Service {
@@ -259,7 +259,9 @@ extension Service {
             permissions: [.read])
 
         public init(identifier: UInt32, name: String, input: InputSourceType) {
-            super.init(type: .inputSource, characteristics: [configuredName, inputSourceType, isConfigured, currentVisibilityState, self.identifier, self.name])
+            super.init(type: .inputSource,
+                       characteristics: [configuredName, inputSourceType, isConfigured,
+                                         currentVisibilityState, self.identifier, self.name])
 
             self.name.value = name.replacingOccurrences(of: " ", with: "")
             configuredName.value = name
@@ -305,7 +307,9 @@ extension Service {
             permissions: [.read])
 
         public init() {
-            super.init(type: .televisionSpeaker, characteristics: [name, mute, active, volumeControlType, volumeSelector, volume])
+            super.init(type: .televisionSpeaker,
+                       characteristics: [name, mute, active, volumeControlType,
+                                         volumeSelector, volume])
         }
     }
 }

--- a/Sources/HAP/Accessories/Television.swift
+++ b/Sources/HAP/Accessories/Television.swift
@@ -1,0 +1,311 @@
+
+extension Accessory {
+    open class Television: Accessory {
+        public let television = Service.Television()
+        public let speaker = Service.TelevisionSpeaker()
+        public var sources = [Service.InputSource]()
+
+        public init(info: Service.Info, inputs: [(String, InputSourceType)], additionalServices: [Service] = []) {
+
+            precondition(inputs.count > 0)
+            var i: UInt32 = 0
+            for (name, type) in inputs {
+                sources.append(Service.InputSource(identifier: i, name: name, input: type))
+                i = i+1
+            }
+            super.init(info: info, type: .television, services: ([television, speaker] + sources as [Service]) + additionalServices)
+            speaker.name.value = "Speaker"
+            television.configuredName.value = info.name.value
+            television.activeIdentifier.value = sources[0].identifier.value
+            television.addLinkedService(speaker)
+
+            for source in sources {
+                television.addLinkedService(source)
+            }
+        }
+    }
+}
+
+public enum Active: UInt8, CharacteristicValueType {
+    case inactive = 0
+    case active = 1
+}
+
+public typealias ActiveIdentifier = UInt32
+public typealias ConfiguredName = String
+
+
+public enum SleepDiscoveryMode: UInt8, CharacteristicValueType {
+    case notDiscoverable = 0
+    case alwaysDiscoverable = 1
+}
+
+public enum ClosedCaptions: UInt8, CharacteristicValueType {
+    case disabled = 0
+    case enabled = 1
+}
+
+public typealias CurrentMediaState = UInt8
+
+public enum TargetMediaState: UInt8, CharacteristicValueType {
+    case play = 0
+    case pause = 1
+    case stop = 2
+}
+
+public enum PictureMode: UInt16, CharacteristicValueType {
+    case other = 0
+    case standard = 1
+    case calibrated = 2
+    case calibratedDark = 3
+    case vivid = 4
+    case game = 5
+    case computer = 6
+    case custom = 7
+    case _other8 = 8
+    case _other9 = 9
+    case _other10 = 10
+    case _other11 = 11
+    case _other12 = 12
+    case _other13 = 13
+}
+
+public enum PowerModeSelection: UInt8, CharacteristicValueType {
+    case show = 0
+    case hide = 1
+}
+
+public enum RemoteKey: UInt8, CharacteristicValueType {
+    case rewind = 0
+    case fastForward = 1
+    case nextTrack = 2
+    case previousTrack = 3
+    case arrowUp = 4
+    case arrowDown = 5
+    case arrowLeft = 6
+    case arrowRight = 7
+    case select = 8
+    case back = 9
+    case exit = 10
+    case playPause = 11
+    case information = 15
+    case _other = 16
+}
+
+public enum InputSourceType: UInt8, CharacteristicValueType {
+    case other = 0
+    case homeScreen = 1
+    case tuner = 2
+    case hdmi = 3
+    case compositeVideo = 4
+    case sVideo = 5
+    case componentVideo = 6
+    case dvi = 7
+    case airplay = 8
+    case usb = 9
+    case application = 10
+}
+
+public enum InputDeviceType: UInt8, CharacteristicValueType {
+    case other = 0
+    case tv = 1
+    case recording = 2
+    case tuner = 3
+    case playback = 4
+    case audioSystem = 5
+}
+
+public typealias Name = String
+public typealias Mute = Bool
+
+public enum CurrentVisibilityState: UInt8, CharacteristicValueType {
+    case shown = 0
+    case hidden = 1
+}
+
+public enum TargetVisibilityState: UInt8, CharacteristicValueType {
+    case shown = 0
+    case hidden = 1
+}
+
+public enum VolumeControlType: UInt8, CharacteristicValueType {
+    case none = 0
+    case relative = 1
+    case relativeWithCurrent = 2
+    case absolute = 3
+}
+
+public enum VolumeSelector: UInt8, CharacteristicValueType {
+    case increment = 0
+    case decrement = 1
+}
+
+public enum IsConfigured: UInt8, CharacteristicValueType {
+    case notConfigured = 0
+    case configured = 1
+}
+
+
+extension Service {
+    open class Television: Service {
+        public let active = GenericCharacteristic<Active>(
+            type: .active,
+            value: .inactive,
+            maxValue: 1,
+            minValue: 0)
+        public let activeIdentifier = GenericCharacteristic<ActiveIdentifier>(
+            type: .activeIdentifier,
+            value: 1)
+        public let configuredName = GenericCharacteristic<ConfiguredName>(
+            type: .configuredName)
+        public let sleepDiscoveryMode = GenericCharacteristic<SleepDiscoveryMode>(
+            type: .sleepDiscoveryMode,
+            value: .alwaysDiscoverable,
+            permissions: [.read, .events])
+
+
+        // Optional Characteristics
+
+        
+        public let brightness = GenericCharacteristic<Brightness>(
+            type: .brightness,
+            value: 100,
+            unit: .percentage,
+            maxValue: 100,
+            minValue: 0,
+            minStep: 1)
+
+        public let closedCaptions = GenericCharacteristic<ClosedCaptions>(
+            type: .closedCaptions,
+            value: .disabled)
+//     TLV8 type - not yet implemented
+//        public let displayOrder = GenericCharacteristic<DisplayOrder>(
+//            type: .displayOrder,
+//            value: .disarmed)
+        public let currentMediaState = GenericCharacteristic<CurrentMediaState>(
+            type: .currentMediaState,
+            value: 0,
+            permissions: [.read, .events],
+            maxValue: 3,
+            minValue: 0)
+        public let targetMediaState = GenericCharacteristic<TargetMediaState>(
+            type: .targetMediaState,
+            value: .play)
+        public let pictureMode = GenericCharacteristic<PictureMode>(
+            type: .pictureMode,
+            value: .standard)
+        public let powerModeSelection = GenericCharacteristic<PowerModeSelection>(
+            type: .powerModeSelection,
+            value: .show,
+            permissions: [.write],
+            maxValue: 1,
+            minValue: 0)
+        public let remoteKey = GenericCharacteristic<RemoteKey>(
+            type: .remoteKey,
+            permissions: [.write],
+            maxValue: 16,
+            minValue: 0)
+
+        public init() {
+            super.init(type: .television, characteristics: [active, activeIdentifier, configuredName, sleepDiscoveryMode, powerModeSelection, remoteKey])
+            self.primary = true
+        }
+    }
+}
+
+
+extension Service {
+    open class InputSource: Service {
+        public let configuredName = GenericCharacteristic<ConfiguredName>(
+            type: .configuredName)
+        public let inputSourceType = GenericCharacteristic<InputSourceType>(
+            type: .inputSourceType,
+            permissions: [.read, .events],
+            maxValue: 10,
+            minValue: 0)
+        public let isConfigured = GenericCharacteristic<IsConfigured>(
+            type: .isConfigured,
+            value: .configured,
+            maxValue: 1,
+            minValue: 0)
+        public let currentVisibilityState = GenericCharacteristic<CurrentVisibilityState>(
+            type: .currentVisibilityState,
+            value: .shown,
+            permissions: [.read, .events],
+            maxValue: 3,
+            minValue: 0)
+
+        // Optional Characteristics
+
+        public let identifier = GenericCharacteristic<UInt32>(
+            type: .identifier,
+            permissions: [.read],
+            minValue: 0,
+            minStep: 1)
+        public let inputDeviceType = GenericCharacteristic<InputDeviceType>(
+            type: .inputDeviceType,
+            value: .other,
+            permissions: [.read, .events],
+            maxValue: 5,
+            minValue: 0)
+       public let targetVisibilityState = GenericCharacteristic<TargetVisibilityState>(
+            type: .targetVisibilityState,
+            value: .shown,
+            maxValue: 1,
+            minValue: 0)
+
+        public let name = GenericCharacteristic<Name>(
+            type: .name,
+            permissions: [.read])
+
+        public init(identifier: UInt32, name: String, input: InputSourceType) {
+            super.init(type: .inputSource, characteristics: [configuredName, inputSourceType, isConfigured, currentVisibilityState, self.identifier, self.name])
+
+            self.name.value = name.replacingOccurrences(of: " ", with: "")
+            configuredName.value = name
+            inputSourceType.value = input
+            self.identifier.value = identifier
+        }
+    }
+}
+
+extension Service {
+    open class TelevisionSpeaker: Service {
+        public let mute = GenericCharacteristic<Mute>(
+            type: .mute,
+            value: false)
+
+        // Optional Characteristics
+
+        public let active = GenericCharacteristic<Active>(
+            type: .active,
+            value: .active,
+            maxValue: 1,
+            minValue: 0)
+       public let volume = GenericCharacteristic<Int>(
+            type: .volume,
+            value: 10,
+            unit: .percentage,
+            maxValue: 100,
+            minValue: 0,
+            minStep: 1)
+        public let volumeControlType = GenericCharacteristic<VolumeControlType>(
+            type: .volumeControlType,
+            value: .absolute,
+            permissions: [.read, .events],
+            maxValue: 3,
+            minValue: 0)
+        public let volumeSelector = GenericCharacteristic<VolumeSelector>(
+            type: .volumeSelector,
+            permissions: [.write],
+            maxValue: 1,
+            minValue: 0)
+        public let name = GenericCharacteristic<Name>(
+            type: .name,
+            permissions: [.read])
+
+        public init() {
+            super.init(type: .televisionSpeaker, characteristics: [name, mute, active, volumeControlType, volumeSelector, volume])
+        }
+    }
+}

--- a/Sources/HAP/Base/Accessory.swift
+++ b/Sources/HAP/Base/Accessory.swift
@@ -45,6 +45,19 @@ public enum AccessoryType: String, Codable {
     case ipCamera = "17"
     case videoDoorBell = "18"
     case airPurifier = "19"
+    case airHeater = "20"       //Not in HAP Spec
+    case airConditioner = "21"  //Not in HAP Spec
+    case airHumidifier = "22"   //Not in HAP Spec
+    case airDehumidifier = "23" //Not in HAP Spec
+    case appleTV = "24"
+
+    case speaker = "26"
+    case airport = "27"
+    case sprinkler = "28"
+    case faucet = "29"
+    case showerHead = "30"
+    case television = "31"
+    case targetController = "32" // Remote Control
 }
 
 open class Accessory: JSONSerializable {

--- a/Sources/HAP/Base/CharacteristicValueType.swift
+++ b/Sources/HAP/Base/CharacteristicValueType.swift
@@ -143,7 +143,7 @@ extension Data: CharacteristicValueType, JSONValueTypeConvertible {
 
 extension RawRepresentable where RawValue: CharacteristicValueType & JSONValueType {
     public init?(value: Any) {
-        guard let rawValue = RawValue.init(value: value) else {
+        guard let rawValue = RawValue(value: value) else {
             return nil
         }
         self.init(rawValue: rawValue)

--- a/Sources/HAP/Base/CharacteristicValueType.swift
+++ b/Sources/HAP/Base/CharacteristicValueType.swift
@@ -34,12 +34,84 @@ extension String: CharacteristicValueType {
 
 extension Int: CharacteristicValueType {
     public init?(value: Any) {
-        guard let int = value as? Int else {
+        if let value = value as? Int {
+             self = value
+        } else if let value = value as? Bool {
+            self = value ? 1 : 0
+        } else {
             return nil
         }
-        self = int
+    }
+    public var asInt: Int {
+        return self
     }
     static public let format = CharacteristicFormat.uint64
+    public var jsonValueType: JSONValueType {
+        return self
+    }
+}
+
+extension UInt8: CharacteristicValueType {
+    public init?(value: Any) {
+        if let value = value as? Int,
+            let int = UInt8(exactly: value) {
+            self = int
+        } else if let value = value as? UInt8 {
+            self = value
+        } else if let value = value as? Bool {
+            self = value ? UInt8(1) : UInt8(0)
+        } else {
+            return nil
+        }
+    }
+    public var asInt: Int {
+        return Int(exactly: self) ?? 0
+    }
+    static public let format = CharacteristicFormat.uint8
+    public var jsonValueType: JSONValueType {
+        return self
+    }
+}
+
+extension UInt16: CharacteristicValueType {
+    public init?(value: Any) {
+        if let value = value as? Int,
+            let int = UInt16(exactly: value) {
+            self = int
+        } else if let value = value as? UInt16 {
+            self = value
+        } else if let value = value as? Bool {
+            self = value ? UInt16(1) : UInt16(0)
+        } else {
+            return nil
+        }
+    }
+    public var asInt: Int {
+        return Int(exactly: self) ?? 0
+    }
+    static public let format = CharacteristicFormat.uint16
+    public var jsonValueType: JSONValueType {
+        return self
+    }
+}
+
+extension UInt32: CharacteristicValueType {
+    public init?(value: Any) {
+        if let value = value as? Int,
+            let int = UInt32(exactly: value) {
+            self = int
+        } else if let value = value as? UInt32 {
+            self = value
+        } else if let value = value as? Bool {
+            self = value ? UInt32(1) : UInt32(0)
+        } else {
+            return nil
+        }
+    }
+    public var asInt: Int {
+        return Int(exactly: self) ?? 0
+    }
+    static public let format = CharacteristicFormat.uint32
     public var jsonValueType: JSONValueType {
         return self
     }
@@ -71,7 +143,7 @@ extension Data: CharacteristicValueType, JSONValueTypeConvertible {
 
 extension RawRepresentable where RawValue: CharacteristicValueType & JSONValueType {
     public init?(value: Any) {
-        guard let rawValue = value as? RawValue else {
+        guard let rawValue = RawValue.init(value: value) else {
             return nil
         }
         self.init(rawValue: rawValue)

--- a/Sources/HAP/Base/Constants.swift
+++ b/Sources/HAP/Base/Constants.swift
@@ -162,6 +162,28 @@ public extension CharacteristicType {
     static let serviceLabelIndex = CharacteristicType(0xCB)
     static let serviceLabelNamespace = CharacteristicType(0xCD)
     static let colorTemperature = CharacteristicType(0xCE)
+    
+    // Television support
+    static let activeIdentifier = CharacteristicType(0xE7)
+    static let configuredName = CharacteristicType(0xE3)
+    static let sleepDiscoveryMode = CharacteristicType(0xE8)
+    static let closedCaptions = CharacteristicType(0xDD)
+    static let displayOrder = CharacteristicType(0x136)
+    static let currentMediaState = CharacteristicType(0xE0)
+    static let targetMediaState = CharacteristicType(0x137)
+    static let pictureMode = CharacteristicType(0xE2)
+    static let powerModeSelection = CharacteristicType(0xDF)
+    static let remoteKey = CharacteristicType(0xE1)
+    static let inputSourceType = CharacteristicType(0xDB)
+    static let inputDeviceType = CharacteristicType(0xDC)
+    static let identifier = CharacteristicType(0xE6)
+    static let currentVisibilityState = CharacteristicType(0x135)
+    static let targetVisibilityState = CharacteristicType(0x134)
+    static let volumeControlType = CharacteristicType(0xE9)
+    static let volumeSelector = CharacteristicType(0xEA)
+    static let isConfigured = CharacteristicType(0xD6)
+
+    // Video streaming
     static let supportedVideoStreamConfiguration = CharacteristicType(0x114)
     static let supportedAudioStreamConfiguration = CharacteristicType(0x115)
     static let supportedRTPConfiguration = CharacteristicType(0x116)
@@ -197,6 +219,8 @@ public enum CharacteristicPermission: String, Codable {
 
     // This characteristic is hidden from the user
     case hidden = "hd"
+
+    case writeResponse = "wr"
 
     // Short-hand for "all" permissions.
     static let ReadWrite: [CharacteristicPermission] = [.read, .write, .events]

--- a/Sources/HAP/Base/Constants.swift
+++ b/Sources/HAP/Base/Constants.swift
@@ -162,7 +162,7 @@ public extension CharacteristicType {
     static let serviceLabelIndex = CharacteristicType(0xCB)
     static let serviceLabelNamespace = CharacteristicType(0xCD)
     static let colorTemperature = CharacteristicType(0xCE)
-    
+
     // Television support
     static let activeIdentifier = CharacteristicType(0xE7)
     static let configuredName = CharacteristicType(0xE3)

--- a/Sources/HAP/Endpoints/characteristics().swift
+++ b/Sources/HAP/Endpoints/characteristics().swift
@@ -55,7 +55,9 @@ func characteristics(device: Device) -> Application {
                 case let _value as String: value = .string(_value)
                 default:
                     value = nil
-                    logger.error("Characteristic \(characteristic.description) has unsupported type: \(type(of:characteristic))")
+                    logger.error(
+                        "Characteristic \(characteristic.description) has unsupported type: " +
+                        "\(type(of: characteristic))")
                 }
 
                 var response = Protocol.Characteristic(aid: path.aid, iid: path.iid, value: value)

--- a/Sources/HAP/Endpoints/characteristics().swift
+++ b/Sources/HAP/Endpoints/characteristics().swift
@@ -47,10 +47,15 @@ func characteristics(device: Device) -> Application {
                 switch characteristic.getValue() {
                 case let _value as Double: value = .double(_value)
                 case let _value as Float: value = .double(Double(_value))
+                case let _value as UInt8: value = .int(Int(_value))
+                case let _value as UInt16: value = .int(Int(_value))
+                case let _value as UInt32: value = .int(Int(_value))
                 case let _value as Int: value = .int(_value)
                 case let _value as Bool: value = .int(_value ? 1 : 0)
                 case let _value as String: value = .string(_value)
-                default: value = nil
+                default:
+                    value = nil
+                    logger.error("Characteristic \(characteristic.description) has unsupported type: \(type(of:characteristic))")
                 }
 
                 var response = Protocol.Characteristic(aid: path.aid, iid: path.iid, value: value)

--- a/Sources/HAP/Server/JSON.swift
+++ b/Sources/HAP/Server/JSON.swift
@@ -15,6 +15,9 @@ extension Dictionary: JSONValueType { }
 extension String: JSONValueType { }
 extension Bool: JSONValueType { }
 extension Int: JSONValueType { }
+extension UInt8: JSONValueType { }
+extension UInt16: JSONValueType { }
+extension UInt32: JSONValueType { }
 extension Double: JSONValueType { }
 extension NSNull: JSONValueType { }
 


### PR DESCRIPTION
Based on KhaosT's HAP-NodeJS implementation, this PR adds the Services and Characteristics for the new Television accessory in the current iOS 12.2 beta.

In order to properly map characteristics, this PR includes support for UInt8, UInt16 and UInt32 based Characteristics. 

Support is added to Service for Linked, Hidden and Primary services.

In order to support the remote control function, I found that the tear down of server connections was too aggressive, so this has been scaled back. I'm running a few instances to test if this reintroduces the port/connection leak that existed before.