### PR TITLE
Ensure access to characteristics happen on the main queue. 

### DIFF
--- a/Sources/HAP/Base/Characteristic.swift
+++ b/Sources/HAP/Base/Characteristic.swift
@@ -75,7 +75,7 @@ public class GenericCharacteristic<T: CharacteristicValueType>: Characteristic, 
                 return
             }
             precondition(
-                !permissions.contains(.read) || value != nil,
+                !permissions.contains(.read) || newValue != nil,
                 "Readable characteristics should have non nil value")
 
             _value = clip(value: newValue)

--- a/Sources/HAP/Endpoints/characteristics().swift
+++ b/Sources/HAP/Endpoints/characteristics().swift
@@ -9,6 +9,16 @@ fileprivate let logger = getLogger("hap.endpoints.characteristics")
 func characteristics(device: Device) -> Responder {
     return { context, request in
         let channel = context.channel
+        var response: HTTPResponse?
+        DispatchQueue.main.sync {
+            response = characteristics(device: device, channel: channel, request: request)
+        }
+        return response!
+    }
+}
+
+// swiftlint:disable:next cyclomatic_complexity
+func characteristics(device: Device, channel: Channel, request: HTTPRequest) -> HTTPResponse {
 
         switch request.method {
         case .GET:
@@ -231,5 +241,4 @@ func characteristics(device: Device) -> Responder {
         default:
             return .badRequest
         }
-    }
 }

--- a/Sources/HAP/Endpoints/root().swift
+++ b/Sources/HAP/Endpoints/root().swift
@@ -26,7 +26,8 @@ func logger(_ application: @escaping Responder) -> Responder {
         let response = application(context, request)
         // swiftlint:disable:next line_length
         logger.info("\(context.channel.remoteAddress?.description ?? "N/A") \(request.method) \(request.urlString) \(response.status.code) \(response.body.count ?? 0)")
-        return response
+        logger.debug("- Response Messagea: \(String(data: response.body.data ?? "nil".data(using: .utf8)!, encoding: .utf8) ?? "-")\n")
+       return response
     }
 }
 

--- a/Sources/HAP/Endpoints/root().swift
+++ b/Sources/HAP/Endpoints/root().swift
@@ -26,7 +26,7 @@ func logger(_ application: @escaping Responder) -> Responder {
         let response = application(context, request)
         // swiftlint:disable:next line_length
         logger.info("\(context.channel.remoteAddress?.description ?? "N/A") \(request.method) \(request.urlString) \(response.status.code) \(response.body.count ?? 0)")
-        logger.debug("- Response Messagea: \(String(data: response.body.data ?? "nil".data(using: .utf8)!, encoding: .utf8) ?? "-")\n")
+        logger.debug("Response Message: \(String(data: response.body.data ?? "nil".data(using: .utf8)!, encoding: .utf8) ?? "-")\n")
        return response
     }
 }

--- a/Sources/HAP/Server/Server.swift
+++ b/Sources/HAP/Server/Server.swift
@@ -68,7 +68,7 @@ public class Server: NSObject, NetServiceDelegate {
             .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
             .childChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
-            .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
+            .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator(minimum: 1200, initial: 2056, maximum: 16392))
 
         logger.debug("binding listening port...")
         do {

--- a/Tests/HAPTests/EndpointTests.swift
+++ b/Tests/HAPTests/EndpointTests.swift
@@ -93,7 +93,8 @@ class EndpointTests: XCTestCase {
         let energy = Energy(info: .init(name: "Energy", serialNumber: "00057"))
         let device = Device(setupCode: "123-44-321", storage: MemoryStorage(), accessory: energy)
         let application = characteristics(device: device)
-        do {
+        let testQueue = DispatchQueue(label: "TestQueue")
+        testQueue.async {
             let response = application(MockContext(), HTTPRequest(uri: "/characteristics?id=\(energy.aid).\(energy.info.name.iid),\(energy.aid).\(energy.service.watt.iid)&meta=1&perms=1&type=1&ev=1"))
             guard let jsonObject = (try? JSONSerialization.jsonObject(with: response.body.data ?? Data(), options: [])) as? [String: [[String: Any]]] else {
                 return XCTFail("Could not decode")
@@ -123,7 +124,8 @@ class EndpointTests: XCTestCase {
         lamp.lightbulb.brightness!.value = 100
         let device = Device(setupCode: "123-44-321", storage: MemoryStorage(), accessory: lamp)
         let application = characteristics(device: device)
-        do {
+        let testQueue = DispatchQueue(label: "TestQueue")
+        testQueue.async {
             let response = application(MockContext(), HTTPRequest(uri: "/characteristics?id=\(lamp.aid).\(lamp.info.manufacturer.iid),\(lamp.aid).\(lamp.info.name.iid)"))
             guard let jsonObject = (try? JSONSerialization.jsonObject(with: response.body.data ?? Data(), options: [])) as? [String: [[String: Any]]] else {
                 return XCTFail("Could not decode")
@@ -143,7 +145,7 @@ class EndpointTests: XCTestCase {
             XCTAssertEqual(nameCharacteristic["value"] as? String, "Night stand left")
         }
 
-        do {
+        testQueue.async {
             let response = application(MockContext(), HTTPRequest(uri: "/characteristics?id=\(lamp.aid).\(lamp.info.name.iid),\(lamp.aid).\(lamp.lightbulb.brightness!.iid)&meta=1&perms=1&type=1&ev=1"))
             guard let jsonObject = (try? JSONSerialization.jsonObject(with: response.body.data ?? Data(), options: [])) as? [String: [[String: Any]]] else {
                 return XCTFail("Could not decode")
@@ -178,12 +180,13 @@ class EndpointTests: XCTestCase {
         let lamp = Accessory.Lightbulb(info: .init(name: "Night stand left", serialNumber: "00057", manufacturer: "Bouke"), isDimmable: true)
         let device = Device(setupCode: "123-44-321", storage: MemoryStorage(), accessory: lamp)
         let application = characteristics(device: device)
+        let testQueue = DispatchQueue(label: "TestQueue")
 
         lamp.lightbulb.powerState.value = false
         lamp.lightbulb.brightness?.value = 0
 
         // turn lamp on
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -200,7 +203,7 @@ class EndpointTests: XCTestCase {
         }
 
         // 50% brightness
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -217,7 +220,7 @@ class EndpointTests: XCTestCase {
         }
 
         // 100% brightness
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -238,6 +241,7 @@ class EndpointTests: XCTestCase {
         let thermostat = Accessory.Thermostat(info: .init(name: "Thermostat", serialNumber: "00058", manufacturer: "Bouke"))
         let device = Device(setupCode: "123-44-321", storage: MemoryStorage(), accessory: thermostat)
         let application = characteristics(device: device)
+        let testQueue = DispatchQueue(label: "TestQueue")
 
         thermostat.thermostat.currentHeatingCoolingState.value = .off
         thermostat.thermostat.currentTemperature.value = 18
@@ -246,7 +250,7 @@ class EndpointTests: XCTestCase {
         thermostat.thermostat.targetTemperature.value = 15
 
         // turn up the heat
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -269,7 +273,7 @@ class EndpointTests: XCTestCase {
         }
 
         // turn up the heat some more (value is an Int on Linux, needs to be cast to Double)
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -286,7 +290,7 @@ class EndpointTests: XCTestCase {
         }
 
         // turn off
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -303,7 +307,7 @@ class EndpointTests: XCTestCase {
         }
 
         // wirting all Apple defined properties
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -328,9 +332,9 @@ class EndpointTests: XCTestCase {
         let lamp = Accessory.Lightbulb(info: .init(name: "Night stand left", serialNumber: "00060"), isDimmable: true)
         let device = Device(bridgeInfo: .init(name: "Test", serialNumber: "00060B"), setupCode: "123-44-321", storage: MemoryStorage(), accessories: [thermostat, lamp])
         let application = characteristics(device: device)
-
+        let testQueue = DispatchQueue(label: "TestQueue")
         // Writing to read only value should not succeed.
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -346,7 +350,7 @@ class EndpointTests: XCTestCase {
         }
 
         // Writing incorrect value should not succeed.
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -365,7 +369,7 @@ class EndpointTests: XCTestCase {
 
         // Writing two values, one should fail as it is read only, the other
         // should succeed.
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -393,7 +397,7 @@ class EndpointTests: XCTestCase {
 
         // Writing two values, both should fail as the first one is read only
         // and the second receives an invalid value.
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -419,7 +423,7 @@ class EndpointTests: XCTestCase {
         }
 
         // Writing two values, one should succeed and the other should fail as it is read only.
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -445,7 +449,7 @@ class EndpointTests: XCTestCase {
         }
 
         // Writing two values, both should fail as they are read only.
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -473,7 +477,7 @@ class EndpointTests: XCTestCase {
 
         // "400 Bad Request" on HAP client error, e.g. a malformed request
         // at least one of `value` or `ev` should be present.
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -488,7 +492,7 @@ class EndpointTests: XCTestCase {
         }
 
         // Leaving out the `iid` field should not succeed.
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -503,7 +507,7 @@ class EndpointTests: XCTestCase {
         }
 
         // Leaving out the `aid` field should not succeed.
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -519,7 +523,7 @@ class EndpointTests: XCTestCase {
 
         // "422 Unprocessable Entity" for a well-formed request that contains
         // invalid parameters.
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -536,7 +540,7 @@ class EndpointTests: XCTestCase {
 
         // "422 Unprocessable Entity" for a well-formed request that contains
         // invalid parameters.
-        do {
+        testQueue.async {
             let jsonObject: [String: [[String: Any]]] = [
                 "characteristics": [
                     [
@@ -562,9 +566,10 @@ class EndpointTests: XCTestCase {
         lamp.lightbulb.brightness!.value = 53
         let device = Device(bridgeInfo: .init(name: "Test", serialNumber: "00063B"), setupCode: "123-44-321", storage: MemoryStorage(), accessories: [lightsensor, thermostat, lamp])
         let application = characteristics(device: device)
+        let testQueue = DispatchQueue(label: "TestQueue")
 
         // First a good one
-        do {
+        testQueue.async {
             let req = "\(lamp.aid).\(lamp.lightbulb.brightness!.iid),\(lightsensor.aid).\(lightsensor.lightSensor.currentLightLevel.iid),\(thermostat.aid).\(thermostat.thermostat.currentTemperature.iid)"
             let response = application(MockContext(), HTTPRequest(uri: "/characteristics?id=\(req)"))
 
@@ -607,7 +612,7 @@ class EndpointTests: XCTestCase {
         }
 
         // trying to read write only access
-        do {
+        testQueue.async {
             let iid = lightsensor.info.identify.iid
             let aid = lightsensor.aid
             let response = application(MockContext(), HTTPRequest(uri: "/characteristics?id=\(aid).\(iid)"))
@@ -619,7 +624,7 @@ class EndpointTests: XCTestCase {
         }
 
         // trying to read write only access and one with read access
-        do {
+        testQueue.async {
             let iid = lightsensor.info.identify.iid
             let aid = lightsensor.aid
             let iid2 = thermostat.thermostat.currentTemperature.iid
@@ -647,7 +652,7 @@ class EndpointTests: XCTestCase {
         }
 
         // trying to read write only access and one with read access, reverse order
-        do {
+        testQueue.async {
             let iid = lightsensor.info.identify.iid
             let aid = lightsensor.aid
             let iid2 = thermostat.thermostat.currentTemperature.iid

--- a/Tests/HAPTests/EndpointTests.swift
+++ b/Tests/HAPTests/EndpointTests.swift
@@ -117,6 +117,9 @@ class EndpointTests: XCTestCase {
             XCTAssertEqual(wattCharacteristic["value"] as? Int, 42)
             XCTAssertEqual(wattCharacteristic["type"] as? String, "E863F10D-079E-48FF-8F27-9C2605A29F52")
         }
+        let expectation = self.expectation(description: "Test Complete")
+        testQueue.async { expectation.fulfill() }
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testGetCharacteristics() {
@@ -174,6 +177,9 @@ class EndpointTests: XCTestCase {
             XCTAssertEqual(brightnessCharacteristic["type"] as? String, "8")
             XCTAssertEqual(brightnessCharacteristic["ev"] as? Bool, true)
         }
+        let expectation = self.expectation(description: "Test Complete")
+        testQueue.async { expectation.fulfill() }
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testPutBoolAndIntCharacteristics() {
@@ -235,6 +241,9 @@ class EndpointTests: XCTestCase {
             XCTAssertEqual(response.status, .noContent)
             XCTAssertEqual(lamp.lightbulb.brightness!.value, 100)
         }
+        let expectation = self.expectation(description: "Test Complete")
+        testQueue.async { expectation.fulfill() }
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testPutDoubleAndEnumCharacteristics() {
@@ -325,6 +334,9 @@ class EndpointTests: XCTestCase {
             XCTAssertEqual(response.status, .noContent)
             XCTAssertEqual(thermostat.thermostat.targetHeatingCoolingState.value, .off)
         }
+        let expectation = self.expectation(description: "Test Complete")
+        testQueue.async { expectation.fulfill() }
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testPutBadCharacteristics() {
@@ -554,6 +566,9 @@ class EndpointTests: XCTestCase {
             let response = application(MockContext(), HTTPRequest(method: .PUT, uri: "/characteristics", body: body))
             XCTAssertEqual(response.status, .unprocessableEntity)
         }
+        let expectation = self.expectation(description: "Test Complete")
+        testQueue.async { expectation.fulfill() }
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testGetBadCharacteristics() {
@@ -678,6 +693,9 @@ class EndpointTests: XCTestCase {
             XCTAssertEqual(therm["status"] as? Int, HAPStatusCodes.success.rawValue)
             XCTAssertEqual(Float(value: therm["value"] as Any), thermostat.thermostat.currentTemperature.value)
         }
+        let expectation = self.expectation(description: "Test Complete")
+        testQueue.async { expectation.fulfill() }
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testAuthentication() {


### PR DESCRIPTION
Two small changes. 

First change corrects the precondition on set characteristic value.

Secondly, the characteristic endpoint is currently running on a NIO queue, causing thread safety issues. 

This PR performs the endpoint on the main queue, to ensure a single queue access the HAP characteristics. A future improvement could be to restructure the entire endpoint architecture to use promises, which would avoid a synchronous call across queues.
