### PR TITLE
Workaround for thread sync violation in disconnectPairings 

### DIFF
--- a/Sources/HAP/Server/ChannelHandlers.swift
+++ b/Sources/HAP/Server/ChannelHandlers.swift
@@ -157,7 +157,13 @@ class ControllerHandler: ChannelDuplexHandler {
 
     private func sync(execute block: () -> Void) {
         // Execute block directly if called on channelsQueue
+
+#if os(macOS)
         let queueLabel = String(validatingUTF8: __dispatch_queue_get_label(nil))
+#elseif os(Linux)
+        let queueLabel = String(validatingUTF8: dispatch_queue_get_label(nil))
+#endif
+
         if queueLabel == "channelsQueue" {
             block()
         } else {


### PR DESCRIPTION
Workaround for thread sync violation in `disconnectPairings`. 

In `disconnectParings`, `close()` is called from a synchronised block on the `channelsSyncQueue`, which propagates down to a call to  `channelInactive()`. `channelInactive` then attempts to run a block synchronously on the same queue, which causes a hard crash.

During testing I found that `channelInactive()` was called multiple times from other NIO queues, but was only called from the `channelsSyncQueue` when removing pairings.

I don't know enough about NIO to know if the call to `close()` is required to be run on the `channelsSyncQueue`. I suspect that it should not, and therefore the correct fix would be to make that call on a different queue.

The workaround uses an undocumented trick to determine whether `channelInactive` is being called on the `channelsSyncQueue` and if it is, then the block is executed directly. If it is being called from a different queue then the block is executed synchronously as originally intended. 

The trick works in macOS and iOS, but I do not know if it works with the linux implementation of GCD.
