### PR TITLE
Fix thread safety in pairing endpoints and ChannelHandlers

### DIFF
--- a/Sources/HAP/Server/ChannelHandlers.swift
+++ b/Sources/HAP/Server/ChannelHandlers.swift
@@ -193,21 +193,25 @@ class ControllerHandler: ChannelDuplexHandler {
 
     func channelActive(ctx: ChannelHandlerContext) {
         let channel = ctx.channel
+        var channelsCount = 0
         channelsSyncQueue.sync {
             self.channels[ObjectIdentifier(channel)] = channel
+            channelsCount = self.channels.count
         }
-        logger.info("Controller \(channel.remoteAddress?.description ?? "N/A") connected, \(self.channels.count) controllers total")
+        logger.info("Controller \(channel.remoteAddress?.description ?? "N/A") connected, \(channelsCount) controllers total")
         ctx.fireChannelActive()
     }
 
     func channelInactive(ctx: ChannelHandlerContext) {
         let channel = ctx.channel
+        var channelsCount = 0
         channelsSyncQueue.sync {
             self.channels.removeValue(forKey: ObjectIdentifier(channel))
             self.pairings.removeValue(forKey: ObjectIdentifier(channel))
+            channelsCount = self.channels.count
         }
         self.removeSubscriptions?(channel)
-        logger.info("Controller \(channel.remoteAddress?.description ?? "N/A") disconnected, \(self.channels.count) controllers total")
+        logger.info("Controller \(channel.remoteAddress?.description ?? "N/A") disconnected, \(channelsCount) controllers total")
         ctx.fireChannelInactive()
     }
 


### PR DESCRIPTION
I've been seeing hard crashes due to unsafe access to shared dictionaries from multiple NIO threads in these functions. I've added code to ensure all accesses are thread-safe. The sessions array may be read concurrently, but writes are exclusive.

Regarding the TODO comment on not freeing memory you wrote, should we setup a timeout to clear sessions if the pairing does not complete, or a background process to flush out old sessions once per hour ?