### PR TITLE
Persist Serial numbers

### DIFF
--- a/Sources/HAP/Server/Device.swift
+++ b/Sources/HAP/Server/Device.swift
@@ -275,7 +275,7 @@ public class Device {
         server?.updateDiscoveryRecord()
     }
 
-    public func removeAccessories(_ unwantedAccessories: [Accessory]) {
+    public func removeAccessories(_ unwantedAccessories: [Accessory], andForgetSerialNumbers: Bool = true) {
         if unwantedAccessories.isEmpty {
             return
         }
@@ -286,8 +286,10 @@ public class Device {
                 preconditionFailure("Removing a non-existant accessory from the Bridge")
             }
             accessories.remove(at: index)
-            let serialNumber = accessory.serialNumber
-            configuration.aidForAccessorySerialNumber.removeValue(forKey: serialNumber)
+            if andForgetSerialNumbers {
+                let serialNumber = accessory.serialNumber
+                configuration.aidForAccessorySerialNumber.removeValue(forKey: serialNumber)
+            }
         }
         // write configuration data to persist updated aid's
         updatedConfiguration()

--- a/Sources/HAP/Server/Device.swift
+++ b/Sources/HAP/Server/Device.swift
@@ -275,7 +275,8 @@ public class Device {
         server?.updateDiscoveryRecord()
     }
 
-    public func removeAccessories(_ unwantedAccessories: [Accessory], andForgetSerialNumbers: Bool = true) {
+    public func removeAccessories(_ unwantedAccessories: [Accessory],
+                                  andForgetSerialNumbers: Bool = false) {
         if unwantedAccessories.isEmpty {
             return
         }


### PR DESCRIPTION
When removing accessories from a Bridge, the current implementation also removes the serial number to AID mapping. If the accessory is added back, a new AID is generated, which is not in line with the HAP spec.

This PR adds an optional parameter `andForgetSerialNumbers:` to `Device.removeAccessories()` to persist the serial number to AID mapping after removing accessories. 

A default value is provided to ensure any existing code operates as before. However I would suggest it may be better to make persistence the default, and only remove the serial number mapping if specifically requested to do so. (i.e making the default value true). What do you think ?

A host application can permanently forget all serial number to AID mappings by removing the Storage.
 