### PR TITLE
EventLoopGroup can be set by Server.init

### DIFF
--- a/Sources/HAP/Controllers/PairVerifyController.swift
+++ b/Sources/HAP/Controllers/PairVerifyController.swift
@@ -127,7 +127,7 @@ class PairVerifyController {
             throw Error.invalidSignature
         }
 
-        logger.info("Pair verify completed")
+        logger.debug("Pair verify completed")
         let result: PairTagTLV8 = [
             (.state, Data(bytes: [PairVerifyStep.finishResponse.rawValue]))
         ]

--- a/Sources/HAP/Server/ChannelHandlers.swift
+++ b/Sources/HAP/Server/ChannelHandlers.swift
@@ -198,7 +198,7 @@ class ControllerHandler: ChannelDuplexHandler {
             self.channels[ObjectIdentifier(channel)] = channel
             channelsCount = self.channels.count
         }
-        logger.info("Controller \(channel.remoteAddress?.description ?? "N/A") connected, \(channelsCount) controllers total")
+        logger.debug("Controller \(channel.remoteAddress?.description ?? "N/A") connected, \(channelsCount) controllers total")
         context.fireChannelActive()
     }
 
@@ -211,7 +211,7 @@ class ControllerHandler: ChannelDuplexHandler {
             channelsCount = self.channels.count
         }
         self.removeSubscriptions?(channel)
-        logger.info("Controller \(channel.remoteAddress?.description ?? "N/A") disconnected, \(channelsCount) controllers total")
+        logger.debug("Controller \(channel.remoteAddress?.description ?? "N/A") disconnected, \(channelsCount) controllers total")
         context.fireChannelInactive()
     }
 


### PR DESCRIPTION
In case someone is managing its own EventLoopGroup as I do in my project RoomCtrlClient4