### PR TITLE
Allow Int based Characteristic values to be initialised by Float or Double

### DIFF
--- a/Sources/HAP/Base/CharacteristicValueType.swift
+++ b/Sources/HAP/Base/CharacteristicValueType.swift
@@ -53,9 +53,13 @@ extension String: CharacteristicValueType {
 extension Int: CharacteristicValueType {
     public init?(value: Any) {
         if let value = value as? Int {
-             self = value
+            self = value
         } else if let value = value as? Bool {
             self = value ? 1 : 0
+        } else if let value = value as? Float {
+            self = Int(value)
+        } else if let value = value as? Double {
+            self = Int(value)
         } else {
             return nil
         }


### PR DESCRIPTION
An interesting bug came up recently, when initialising a `colourTemperature` characteristic, where the default value in the factory method in `Generated.swift` was outside the max and min range specified in my init call. The value of the characteristic is an `Int` type, but the min and max values in `Generated` are stored as `Double`. Creating the characteristic with that new range resulted in a crash, as the double max an min values could not be converted to `Int`

This patch adds the ability to create an `Int` characteristic from a `Double` or `Float`.