### PR TITLE
Cryptokit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ matrix:
       osx_image: xcode10.3
       before_install:
         - brew install libsodium
+    - name: Swift 5.3
+      os: osx
+      osx_image: xcode12
+      before_install:
+        - brew install libsodium
     - name: Swift 5.0
       os: linux
       dist: trusty

--- a/Sources/HAP/Controllers/PairSetupController.swift
+++ b/Sources/HAP/Controllers/PairSetupController.swift
@@ -61,7 +61,7 @@ class PairSetupController {
         logger.debug("<-- B \(serverPublicKey.hex)")
 
         let result: PairTagTLV8 = [
-            (.state, Data(bytes: [PairSetupStep.startResponse.rawValue])),
+            (.state, Data([PairSetupStep.startResponse.rawValue])),
             (.publicKey, serverPublicKey),
             (.salt, salt)
         ]
@@ -87,7 +87,7 @@ class PairSetupController {
         logger.debug("<-- HAMK \(serverKeyProof.hex)")
 
         let result: PairTagTLV8 = [
-            (.state, Data(bytes: [PairSetupStep.verifyResponse.rawValue])),
+            (.state, Data([PairSetupStep.verifyResponse.rawValue])),
             (.proof, serverKeyProof)
         ]
         return result
@@ -146,7 +146,7 @@ class PairSetupController {
         device.add(pairing: Pairing(identifier: username, publicKey: publicKey, role: .admin))
 
         let resultOuter: PairTagTLV8 = [
-            (.state, Data(bytes: [PairSetupStep.keyExchangeResponse.rawValue])),
+            (.state, Data([PairSetupStep.keyExchangeResponse.rawValue])),
             (.encryptedData, encryptedResultInner)
         ]
         return resultOuter

--- a/Sources/HAP/Controllers/PairVerifyController.swift
+++ b/Sources/HAP/Controllers/PairVerifyController.swift
@@ -24,6 +24,9 @@ class PairVerifyController {
             self.otherPublicKey = otherPublicKey
             self.sharedSecret = sharedSecret
         }
+        func stringEncodedSharedSecret() -> String {
+            return (secretKey + otherPublicKey).base64EncodedString()
+        }
     }
 
     enum Error: Swift.Error {

--- a/Sources/HAP/Controllers/PairVerifyController.swift
+++ b/Sources/HAP/Controllers/PairVerifyController.swift
@@ -71,7 +71,7 @@ class PairVerifyController {
         }
 
         let resultOuter: PairTagTLV8 = [
-            (.state, Data(bytes: [PairVerifyStep.startResponse.rawValue])),
+            (.state, Data([PairVerifyStep.startResponse.rawValue])),
             (.publicKey, session.publicKey),
             (.encryptedData, encryptedResultInner)
         ]
@@ -120,7 +120,7 @@ class PairVerifyController {
 
         logger.info("Pair verify completed")
         let result: PairTagTLV8 = [
-            (.state, Data(bytes: [PairVerifyStep.finishResponse.rawValue]))
+            (.state, Data([PairVerifyStep.finishResponse.rawValue]))
         ]
         return (result, pairing)
     }

--- a/Sources/HAP/Endpoints/accessories().swift
+++ b/Sources/HAP/Endpoints/accessories().swift
@@ -1,6 +1,5 @@
 import Logging
 import Foundation
-import HKDF
 import HTTP
 
 fileprivate let logger = Logger(label: "hap.endpoints.accessories")

--- a/Sources/HAP/Endpoints/characteristics().swift
+++ b/Sources/HAP/Endpoints/characteristics().swift
@@ -1,5 +1,4 @@
 import Foundation
-import HKDF
 import Logging
 import HTTP
 

--- a/Sources/HAP/Endpoints/pairSetup().swift
+++ b/Sources/HAP/Endpoints/pairSetup().swift
@@ -89,28 +89,28 @@ func pairSetup(device: Device) -> Responder {
             switch error {
             case PairSetupController.Error.invalidParameters:
                 response = [
-                    (.state, Data(bytes: [PairSetupStep.waiting.rawValue])),
-                    (.error, Data(bytes: [PairError.unknown.rawValue]))
+                    (.state, Data([PairSetupStep.waiting.rawValue])),
+                    (.error, Data([PairError.unknown.rawValue]))
                 ]
             case PairSetupController.Error.alreadyPaired:
                 response = [
-                    (.state, Data(bytes: [PairSetupStep.startResponse.rawValue])),
-                    (.error, Data(bytes: [PairError.unavailable.rawValue]))
+                    (.state, Data([PairSetupStep.startResponse.rawValue])),
+                    (.error, Data([PairError.unavailable.rawValue]))
                 ]
             case PairSetupController.Error.alreadyPairing:
                 response = [
-                    (.state, Data(bytes: [PairSetupStep.startResponse.rawValue])),
-                    (.error, Data(bytes: [PairError.busy.rawValue]))
+                    (.state, Data([PairSetupStep.startResponse.rawValue])),
+                    (.error, Data([PairError.busy.rawValue]))
                 ]
             case PairSetupController.Error.invalidSetupState:
                 response = [
-                    (.state, Data(bytes: [PairSetupStep.verifyResponse.rawValue])),
-                    (.error, Data(bytes: [PairError.unknown.rawValue]))
+                    (.state, Data([PairSetupStep.verifyResponse.rawValue])),
+                    (.error, Data([PairError.unknown.rawValue]))
                 ]
             case PairSetupController.Error.authenticationFailed:
                 response = [
-                    (.state, Data(bytes: [PairSetupStep.verifyResponse.rawValue])),
-                    (.error, Data(bytes: [PairError.authenticationFailed.rawValue]))
+                    (.state, Data([PairSetupStep.verifyResponse.rawValue])),
+                    (.error, Data([PairError.authenticationFailed.rawValue]))
                 ]
             default:
                 response = nil

--- a/Sources/HAP/Endpoints/pairVerify().swift
+++ b/Sources/HAP/Endpoints/pairVerify().swift
@@ -47,14 +47,14 @@ func pairVerify(device: Device) -> Responder {
 
             case .startRequest:
                 let (response, session) = try controller.startRequest(data)
-                setSession(for:context, to: session)
+                setSession(for: context, to: session)
                 return HTTPResponse(tags: response)
 
             case .finishRequest:
                 defer {
-                    setSession(for:context, to: nil)
+                    setSession(for: context, to: nil)
                 }
-                guard let session = getSession(for:context) else {
+                guard let session = getSession(for: context) else {
                     throw Error.noSession
                 }
 

--- a/Sources/HAP/Endpoints/pairVerify().swift
+++ b/Sources/HAP/Endpoints/pairVerify().swift
@@ -63,7 +63,7 @@ func pairVerify(device: Device) -> Responder {
 
                 return HTTPResponse(
                     headers: HTTPHeaders([
-                        ("x-shared-key", session.sharedSecret.base64EncodedString()),
+                        ("x-shared-key", session.stringEncodedSharedSecret()),
                         ("Content-Type", "application/pairing+tlv8")
                     ]),
                     body: encode(result))

--- a/Sources/HAP/Security/Authenticator.swift
+++ b/Sources/HAP/Security/Authenticator.swift
@@ -1,0 +1,136 @@
+import Cryptor
+import Foundation
+import HKDF
+import SRP
+
+class Authenticator {
+
+    internal let server: SRP.Server
+    private var encryptionKey: HAPSymmetricKey?
+
+    init(username: String,
+         salt: Data,
+         verificationKey: Data,
+         privateKey: Data? = nil) {
+
+        self.server = SRP.Server(username: username,
+                                 salt: salt,
+                                 verificationKey: verificationKey,
+                                 group: .N3072,
+                                 algorithm: .sha512)
+    }
+
+    /// Returns the challenge. This method is a no-op.
+    ///
+    /// - Returns: `salt` (s) and `publicKey` (B)
+    public func getChallenge() -> (salt: Data, publicKey: Data) {
+        return server.getChallenge()
+    }
+
+    /// Verify that the client did generate the correct `sessionKey`
+    /// from their password and the challenge we provided. We'll generate
+    /// the `sessionKey` as well and proof the client we have posession
+    /// of the password verifier and thus generated the same `sessionKey`
+    /// from that.
+    ///
+    /// - Parameters:
+    ///   - clientPublicKey: client's public key
+    ///   - clientKeyProof: client's proof of `sessionKey`
+    /// - Returns: our proof of `sessionKey` (H(A|M|K))
+    /// - Throws:
+    ///    - `AuthenticationFailure.invalidPublicKey` if the client's public
+    ///      key is invalid (i.e. B % N is zero).
+    ///    - `AuthenticationFailure.keyProofMismatch` if the proof
+    ///      doesn't match our own.
+    public func verifySession(publicKey clientPublicKey: Data, keyProof clientKeyProof: Data) throws -> Data {
+        return try server.verifySession(publicKey: clientPublicKey, keyProof: clientKeyProof)
+    }
+
+    public func decrypt(encryptedData: Data, nonce: String) -> Data? {
+        self.encryptionKey = HKDF.deriveKey(algorithm: .sha512,
+                                            seed: server.sessionKey!,
+                                            info: "Pair-Setup-Encrypt-Info".data(using: .utf8)!,
+                                            salt: "Pair-Setup-Encrypt-Salt".data(using: .utf8)!,
+                                            count: 32)
+        guard let encryptionKey = self.encryptionKey else {
+            return nil
+        }
+        return try? ChaCha20Poly1305.decrypt(cipher: encryptedData,
+                                             nonce: nonce.data(using: .utf8)!,
+                                             key: encryptionKey)
+    }
+
+    public func verifyID(username: Data, publicKey: Data, signatureIn: Data, device: Device) -> Data? {
+        return self.verifyID(username: username,
+                             publicKey: publicKey,
+                             signatureIn: signatureIn,
+                             deviceID: device.identifier,
+                             devicePublicKey: device.publicKey,
+                             devicePrivateKey: device.privateKey)
+    }
+
+    // swiftlint:disable:next function_parameter_count multiline_parameters
+    internal func verifyID(username: Data, publicKey: Data, signatureIn: Data,
+                           deviceID: String, devicePublicKey: Data, devicePrivateKey: Data) -> Data? {
+        let hashIn = HKDF.deriveKey(algorithm: .sha512,
+                                    seed: server.sessionKey!,
+                                    info: "Pair-Setup-Controller-Sign-Info".data(using: .utf8)!,
+                                    salt: "Pair-Setup-Controller-Sign-Salt".data(using: .utf8)!,
+                                    count: 32).data +
+            username +
+        publicKey
+
+        do {
+            try Ed25519.verify(publicKey: publicKey, message: hashIn, signature: signatureIn)
+        } catch {
+            return nil
+        }
+
+        let hashOut = HKDF.deriveKey(algorithm: .sha512,
+                                     seed: server.sessionKey!,
+                                     info: "Pair-Setup-Accessory-Sign-Info".data(using: .utf8)!,
+                                     salt: "Pair-Setup-Accessory-Sign-Salt".data(using: .utf8)!,
+                                     count: 32).data +
+            deviceID.data(using: .utf8)! +
+            devicePublicKey
+
+        return try? Ed25519.sign(privateKey: devicePrivateKey, message: hashOut)
+    }
+
+    public func encrypt(message: Data, nonce: String) -> Data? {
+        guard let encryptionKey = self.encryptionKey else {
+            return nil
+        }
+
+        return try? ChaCha20Poly1305.encrypt(message: message,
+                                             nonce: nonce.data(using: .utf8)!,
+                                             key: encryptionKey)
+    }
+
+    /// Creates the salted verification key based on a user's username and
+    /// password. Only the salt and verification key need to be stored on the
+    /// server, there's no need to keep the plain-text password.
+    ///
+    /// Keep the verification key private, as it can be used to brute-force
+    /// the password from.
+    ///
+    /// - Parameters:
+    ///   - username: user's username
+    ///   - password: user's password
+    ///   - salt: (optional) custom salt value; if providing a salt, make sure to
+    ///       provide a good random salt of at least 16 bytes. Default is to
+    ///       generate a salt of 16 bytes.
+    /// - Returns: salt (s) and verification key (v)
+    public static func createSaltedVerificationKey(
+        username: String,
+        password: String,
+        salt: Data? = nil
+    )
+        -> (salt: Data, verificationKey: Data) {
+            return SRP.createSaltedVerificationKey(username: username,
+                                                   password: password,
+                                                   salt: salt,
+                                                   group: .N3072,
+                                                   algorithm: .sha512)
+    }
+}

--- a/Sources/HAP/Security/ChaCha20Poly1305.swift
+++ b/Sources/HAP/Security/ChaCha20Poly1305.swift
@@ -202,7 +202,7 @@ extension ChaCha20Poly1305 {
 
 #endif
 
-@available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, macCatalyst 13, *)
+@available(OSX 10.15, iOS 13, *)
 extension ChaCha20Poly1305 {
     internal static func CK_encrypt(message: Data, additional: Data? = nil, nonce: Data, key: SymmetricKey) throws -> Data {
         do {

--- a/Sources/HAP/Security/ChaCha20Poly1305.swift
+++ b/Sources/HAP/Security/ChaCha20Poly1305.swift
@@ -18,11 +18,11 @@ class ChaCha20Poly1305 {
 
 #if canImport(CryptoKit)
 import CryptoKit
-#endif
 
 extension ChaCha20Poly1305 {
 
-    @inlinable static func encrypt(message: Data, additional: Data = Data(), nonce: Data, key: HAPSymmetricKey) throws -> Data {
+    @inlinable
+    static func encrypt(message: Data, additional: Data = Data(), nonce: Data, key: HAPSymmetricKey) throws -> Data {
         if #available(macOS 10.15, iOS 13, *) {
             return try CK_encrypt(message: message, nonce: nonce, key: symmetricKey(key))
         }
@@ -34,7 +34,8 @@ extension ChaCha20Poly1305 {
         #endif
     }
 
-    @inlinable static func decrypt(cipher: Data, additional: Data = Data(), nonce: Data, key: HAPSymmetricKey) throws -> Data {
+    @inlinable
+    static func decrypt(cipher: Data, additional: Data = Data(), nonce: Data, key: HAPSymmetricKey) throws -> Data {
         if #available(macOS 10.15, iOS 13, *) {
             return try CK_decrypt(cipher: cipher, nonce: nonce, key: symmetricKey(key))
         }
@@ -46,6 +47,7 @@ extension ChaCha20Poly1305 {
         #endif
     }
 
+    @inlinable
     static func encrypt(message: inout ByteBuffer, additional: ByteBufferView, nonce: Data, key: HAPSymmetricKey, cipher: inout ByteBuffer) throws {
         if #available(macOS 10.15, iOS 13, *) {
             try CK_encrypt(message: &message, additional: additional, nonce: nonce, key: symmetricKey(key), cipher: &cipher)
@@ -58,6 +60,7 @@ extension ChaCha20Poly1305 {
         #endif
     }
 
+    @inlinable
     static func decrypt(cipher: inout ByteBuffer, additional: inout ByteBuffer, nonce: Data, key: HAPSymmetricKey, message: inout ByteBuffer) throws {
 
         if #available(macOS 10.15, iOS 13, *) {
@@ -80,6 +83,32 @@ extension ChaCha20Poly1305 {
         }
     }
 }
+
+#else  // No CryptoKit
+
+extension ChaCha20Poly1305 {
+
+    @inlinable
+    static func encrypt(message: Data, additional: Data = Data(), nonce: Data, key: HAPSymmetricKey) throws -> Data {
+        return try SD_encrypt(message: message, additional: additional, nonce: nonce, key: key as! Data)
+    }
+
+    @inlinable
+    static func decrypt(cipher: Data, additional: Data = Data(), nonce: Data, key: HAPSymmetricKey) throws -> Data {
+        return try SD_decrypt(cipher: cipher, additional: additional, nonce: nonce, key: key as! Data)
+    }
+
+    @inlinable
+    static func encrypt(message: inout ByteBuffer, additional: ByteBufferView, nonce: Data, key: HAPSymmetricKey, cipher: inout ByteBuffer) throws {
+        try SD_encrypt(message: &message, additional: additional, nonce: nonce, key: key as! Data, cipher: &cipher)
+    }
+
+    @inlinable
+    static func decrypt(cipher: inout ByteBuffer, additional: inout ByteBuffer, nonce: Data, key: HAPSymmetricKey, message: inout ByteBuffer) throws {
+        try SD_decrypt(cipher: &cipher, additional: &additional, nonce: nonce, key: key as! Data, message: &message)
+    }
+}
+#endif
 
 #if !(os(macOS) && arch(arm64))
 import CLibSodium
@@ -202,6 +231,7 @@ extension ChaCha20Poly1305 {
 
 #endif
 
+#if canImport(CryptoKit)
 @available(OSX 10.15, iOS 13, *)
 extension ChaCha20Poly1305 {
     internal static func CK_encrypt(message: Data, additional: Data? = nil, nonce: Data, key: SymmetricKey) throws -> Data {
@@ -262,3 +292,4 @@ extension ChaCha20Poly1305 {
         }
     }
 }
+#endif

--- a/Sources/HAP/Security/Cryptographer.swift
+++ b/Sources/HAP/Security/Cryptographer.swift
@@ -27,7 +27,7 @@ class Cryptographer {
     let decryptKey: HAPSymmetricKey
     let encryptKey: HAPSymmetricKey
 
-    init(sharedKey: Data) {
+    init(sharedKey: HAPSharedSecret) {
         logger.debug("Shared key: \(sharedKey.hex)")
         decryptKey = Keys.deriveSha512(
                                     seed: sharedKey,

--- a/Sources/HAP/Security/Ed25519.swift
+++ b/Sources/HAP/Security/Ed25519.swift
@@ -1,16 +1,18 @@
 // swiftlint:disable identifier_name no_grouping_extension
 import Foundation
 
-#if canImport(CryptoKit)
-import CryptoKit
-#endif
-
 class Ed25519 {
     enum Error: Swift.Error {
         case invalidSignature
         case couldNotSign
     }
+}
+#if canImport(CryptoKit)
+import CryptoKit
 
+extension Ed25519 {
+
+    @inlinable
     static func verify(publicKey: Data, message: Data, signature: Data) throws {
         if #available(macOS 10.15, iOS 13, *) {
             try CK_verify(publicKey: publicKey, message: message, signature: signature)
@@ -19,6 +21,7 @@ class Ed25519 {
         }
     }
 
+    @inlinable
     static func sign(privateKey: Data, message: Data) throws -> Data {
         if #available(macOS 10.15, iOS 13, *) {
             return try CK_sign(privateKey: privateKey, message: message)
@@ -27,6 +30,7 @@ class Ed25519 {
         }
     }
 
+    @inlinable
     static func generateSignKeypair() -> (publicKey: Data, privateKey: Data) {
         if #available(macOS 10.15, iOS 13, *) {
             return CK_generateSignKeypair()
@@ -35,6 +39,25 @@ class Ed25519 {
         }
     }
 }
+#else // No CrytoKit
+extension Ed25519 {
+
+    @inlinable
+    static func verify(publicKey: Data, message: Data, signature: Data) throws {
+        try SD_verify(publicKey: publicKey, message: message, signature: signature)
+    }
+
+    @inlinable
+    static func sign(privateKey: Data, message: Data) throws -> Data {
+        return try SD_sign(privateKey: privateKey, message: message)
+    }
+
+    @inlinable
+    static func generateSignKeypair() -> (publicKey: Data, privateKey: Data) {
+        return SD_generateSignKeypair()
+    }
+}
+#endif
 
 #if !(os(macOS) && arch(arm64))
 import CLibSodium

--- a/Sources/HAP/Security/Ed25519.swift
+++ b/Sources/HAP/Security/Ed25519.swift
@@ -101,7 +101,7 @@ extension Ed25519 {
 
 #if canImport(CryptoKit)
 
-@available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, macCatalyst 13, *)
+@available(OSX 10.15, iOS 13, *)
 extension Ed25519 {
     static func CK_verify(publicKey pkData: Data, message: Data, signature: Data) throws {
         guard signature.count == 64,

--- a/Sources/HAP/Security/HAPCrypto-CryptoKit.swift
+++ b/Sources/HAP/Security/HAPCrypto-CryptoKit.swift
@@ -1,0 +1,142 @@
+import Foundation
+import NIO
+
+#if canImport(CryptoKit)
+import CryptoKit
+/*
+@available(macOS 10.15, iOS 13, *)
+extension SharedSecret: HAPSharedSecret {
+    var data: Data {
+        return withUnsafeBytes {
+            return Data($0)
+        }
+    }
+    func base64EncodedString() -> String {
+        return data.base64EncodedString()
+    }
+    public var hex: String {
+        return data.hex
+    }
+}
+
+@available(macOS 10.15, iOS 13, *)
+extension SymmetricKey: HAPSymmetricKey {
+    var data: Data {
+        return withUnsafeBytes {
+            return Data($0)
+        }
+    }
+    public var hex: String {
+        return data.hex
+    }
+}
+*/
+
+@available(OSX 10.15, iOS 13, *)
+extension HAPCrypto {
+    static func CK_verify(publicKey pkData: Data, message: Data, signature: Data) throws {
+        guard signature.count == 64,
+            let publicKey = try? Curve25519.Signing.PublicKey(rawRepresentation: pkData) else {
+            throw Error.invalidSignature
+        }
+
+        if !publicKey.isValidSignature(signature, for: message) {
+            throw Error.invalidSignature
+        }
+    }
+
+    static func CK_sign(privateKey pkData: Data, message: Data) throws -> Data {
+        do {
+            let privateKey = try Curve25519.Signing.PrivateKey(rawRepresentation: pkData)
+            return try privateKey.signature(for: message)
+        } catch {
+            throw Error.couldNotSign
+        }
+    }
+
+    static func CK_generateSignKeypair() -> (publicKey: Data, privateKey: Data) {
+        let privateKey = Curve25519.Signing.PrivateKey()
+        return(privateKey.publicKey.rawRepresentation, privateKey.rawRepresentation)
+    }
+}
+@available(OSX 10.15, iOS 13, *)
+extension HAPCrypto {
+    internal static func CK_encrypt(message: Data, additional: Data? = nil, nonce: Data, key: SymmetricKey) throws -> Data {
+        do {
+            let n = try ChaChaPoly.Nonce(data: upgradeNonce(nonce))
+            if let ad = additional {
+                let sealed = try ChaChaPoly.seal(message, using: key, nonce: n, authenticating: ad)
+                return sealed.ciphertext + sealed.tag
+            }
+            let sealed = try ChaChaPoly.seal(message, using: key, nonce: n)
+            return sealed.ciphertext + sealed.tag
+
+        } catch {
+            throw Error.couldNotEncrypt
+        }
+    }
+    internal static func CK_decrypt(cipher: Data, additional: Data? = nil, nonce: Data, key: SymmetricKey) throws -> Data {
+
+        do {
+            let n = try ChaChaPoly.Nonce(data: upgradeNonce(nonce))
+            let box = try ChaChaPoly.SealedBox(nonce: n, ciphertext: cipher.prefix(cipher.count - 16), tag: cipher.suffix(16))
+            if let ad = additional {
+                return try ChaChaPoly.open(box, using: key, authenticating: ad)
+            }
+
+            return try ChaChaPoly.open(box, using: key)
+
+        } catch {
+            throw Error.couldNotDecrypt
+        }
+    }
+
+    internal static func CK_encrypt(message: inout ByteBuffer, additional: ByteBufferView, nonce: Data, key: SymmetricKey, cipher: inout ByteBuffer) throws {
+        let nonce = upgradeNonce(nonce)
+        let messageLength = message.readableBytes
+        let ad = additional.withUnsafeBytes { Data($0) }
+        if let message = message.getData(at: message.readerIndex, length: messageLength) {
+            let data = try ChaCha20Poly1305.CK_encrypt(message: message, additional: ad, nonce: nonce, key: key)
+            cipher.writeBytes(data)
+            return
+        } else {
+            throw Error.couldNotEncrypt
+        }
+    }
+
+    internal static func CK_decrypt(cipher: inout ByteBuffer, additional: inout ByteBuffer, nonce: Data, key: SymmetricKey, message: inout ByteBuffer) throws {
+
+        let nonce = upgradeNonce(nonce)
+        let cipherLength = cipher.readableBytes
+        let additionalLength = additional.readableBytes
+        let ad = additional.getData(at: additional.readerIndex, length: additionalLength)
+        if let cipher = cipher.getData(at: cipher.readerIndex, length: cipherLength) {
+            let data = try ChaCha20Poly1305.CK_decrypt(cipher: cipher, additional: ad, nonce: nonce, key: key)
+            message.writeBytes(data)
+            return
+        } else {
+            throw Error.couldNotDecrypt
+        }
+    }
+}
+@available(macOS 10.15, iOS 13, *)
+extension HAPCrypto {
+    internal static func CK_public(secretKey: Data) -> Data? {
+        do {
+            let privateKey = try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: secretKey)
+            return privateKey.publicKey.rawRepresentation
+        } catch {
+            return nil
+        }
+    }
+    internal static func CK_sharedSecret(_ secretKey: Data, otherPublicKey: Data) -> HAPSharedSecret? {
+        do {
+            let sharedPublicKey = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: otherPublicKey)
+            let privateKey = try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: secretKey)
+            return try? privateKey.sharedSecretFromKeyAgreement(with: sharedPublicKey)
+        } catch {
+            return nil
+        }
+    }
+}
+#endif

--- a/Sources/HAP/Security/HAPCrypto-Sodium.swift
+++ b/Sources/HAP/Security/HAPCrypto-Sodium.swift
@@ -1,0 +1,218 @@
+import Foundation
+import NIO
+
+/*
+extension Data: HAPSharedSecret, HAPSymmetricKey {
+
+    @inlinable var data: Data {
+        return self
+    }
+
+    @inlinable func base64EncodedString() -> String {
+        return self.base64EncodedString(options: [])
+    }
+    public var hex: String {
+        return self.reduce("") { $0 + String(format: "%02x", $1) }
+    }
+}
+*/
+
+#if !((os(macOS) && arch(arm64)) || NO_LIB_SODIUM)
+
+import CLibSodium
+
+extension HAPCrypto {
+    static func SD_verify(publicKey: Data, message: Data, signature: Data) throws {
+        guard signature.count == Int(crypto_sign_BYTES) else {
+            throw Error.invalidSignature
+        }
+        guard signature.withUnsafeBytes({ pSignature in
+            message.withUnsafeBytes { pMessage in
+                publicKey.withUnsafeBytes { pPublicKey in
+                    crypto_sign_verify_detached(pSignature, pMessage, UInt64(message.count), pPublicKey)
+                }
+            }
+        }) == 0 else {
+            throw Error.invalidSignature
+        }
+    }
+
+    static func SD_sign(privateKey: Data, message: Data) throws -> Data {
+        var signature = Data(count: Int(crypto_sign_BYTES))
+        guard signature.withUnsafeMutableBytes({ sig -> Int32 in
+            message.withUnsafeBytes { m -> Int32 in
+                privateKey.withUnsafeBytes { sk -> Int32 in
+                    crypto_sign_detached(sig, nil, m, UInt64(message.count), sk)
+                }
+            }
+        }) == 0 else {
+            throw Error.couldNotSign
+        }
+        return signature
+    }
+
+    static func SD_generateSignKeypair() -> (publicKey: Data, privateKey: Data) {
+        var pk = Data(count: Int(crypto_sign_PUBLICKEYBYTES))
+        var sk = Data(count: 64) // crypto_sign_SECRETKEYBYTES is not available
+        precondition(pk.withUnsafeMutableBytes({ pk in
+            sk.withUnsafeMutableBytes { sk in
+                crypto_sign_keypair(pk, sk)
+            }
+        }) == 0, "Could not generate keypair")
+        return (pk, sk)
+    }
+}
+extension HAPCrypto {
+
+    internal static func SD_encrypt(message: Data, additional: Data = Data(), nonce: Data, key: Data) throws -> Data {
+        let nonce = upgradeNonce(nonce)
+        var cipher = Data(count: message.count + Int(crypto_aead_chacha20poly1305_ABYTES))
+        let result = cipher.withUnsafeMutableBytes { c in
+            message.withUnsafeBytes { m in
+                additional.withUnsafeBytes { ad in
+                    nonce.withUnsafeBytes { npub in
+                        key.withUnsafeBytes { k in
+                            crypto_aead_chacha20poly1305_ietf_encrypt(c, nil, m, UInt64(message.count), ad, UInt64(additional.count), nil, npub, k)
+                        }
+                    }
+                }
+            }
+        }
+        guard result == 0 else {
+            throw Error.couldNotEncrypt
+        }
+        return cipher
+    }
+
+    internal static func SD_encrypt(message: inout ByteBuffer, additional: ByteBufferView, nonce: Data, key: Data, cipher: inout ByteBuffer) throws {
+        let nonce = upgradeNonce(nonce)
+        let messageLength = UInt64(message.readableBytes)
+        cipher.reserveWritableCapacity(message.readableBytes + Int(crypto_aead_chacha20poly1305_ABYTES))
+        let additionalLength = UInt64(additional.count)
+        let cipherLength = UnsafeMutablePointer<UInt64>.allocate(capacity: 1)
+        let result = cipher.withUnsafeMutableWritableBytes { (cBuffer: UnsafeMutableRawBufferPointer) -> Int32 in
+            let cPointer = cBuffer.baseAddress!.bindMemory(to: UInt8.self, capacity: 1)
+            return message.withUnsafeMutableReadableBytes { (mBuffer: UnsafeMutableRawBufferPointer) -> Int32 in
+                let mPointer = UnsafePointer(mBuffer.baseAddress!.bindMemory(to: UInt8.self, capacity: 1))
+                return additional.withUnsafeBytes { (adBuffer: UnsafeRawBufferPointer) -> Int32 in
+                    let adPointer = adBuffer.baseAddress!.bindMemory(to: UInt8.self, capacity: 1)
+                    return nonce.withUnsafeBytes { (npub: UnsafePointer<UInt8>) -> Int32 in
+                        key.withUnsafeBytes { (k: UnsafePointer<UInt8>) -> Int32 in
+                            crypto_aead_chacha20poly1305_ietf_encrypt(cPointer, cipherLength, mPointer, messageLength, adPointer, additionalLength, nil, npub, k)
+                        }
+                    }
+                }
+            }
+        }
+        guard result == 0 else {
+            throw Error.couldNotEncrypt
+        }
+        cipher.moveWriterIndex(forwardBy: Int(cipherLength.pointee))
+    }
+
+    internal static func SD_decrypt(cipher: Data, additional: Data = Data(), nonce: Data, key: Data) throws -> Data {
+        let nonce = upgradeNonce(nonce)
+        var message = Data(count: cipher.count - Int(crypto_aead_chacha20poly1305_ietf_ABYTES))
+        let result = message.withUnsafeMutableBytes { (m: UnsafeMutablePointer<UInt8>) -> Int32 in
+            cipher.withUnsafeBytes { (c: UnsafePointer<UInt8>) -> Int32 in
+                additional.withUnsafeBytes { (ad: UnsafePointer<UInt8>) -> Int32 in
+                    nonce.withUnsafeBytes { (npub: UnsafePointer<UInt8>) -> Int32 in
+                        key.withUnsafeBytes { (k: UnsafePointer<UInt8>) -> Int32 in
+                            crypto_aead_chacha20poly1305_ietf_decrypt(m, nil, nil, c, UInt64(cipher.count), ad, UInt64(additional.count), npub, k)
+                        }
+                    }
+                }
+            }
+        }
+        guard result == 0 else {
+            throw Error.couldNotDecrypt
+        }
+        return message
+    }
+
+    internal static func SD_decrypt(cipher: inout ByteBuffer, additional: inout ByteBuffer, nonce: Data, key: Data, message: inout ByteBuffer) throws {
+        let nonce = upgradeNonce(nonce)
+        message.reserveWritableCapacity(cipher.readableBytes - Int(crypto_aead_chacha20poly1305_ietf_ABYTES))
+        let cipherLength = UInt64(cipher.readableBytes)
+        let additionalLength = UInt64(additional.readableBytes)
+        let messageLength = UnsafeMutablePointer<UInt64>.allocate(capacity: 1)
+        let result = message.withUnsafeMutableWritableBytes { (mBuffer: UnsafeMutableRawBufferPointer) -> Int32 in
+            let mPointer = mBuffer.baseAddress!.bindMemory(to: UInt8.self, capacity: 1)
+            return cipher.withUnsafeMutableReadableBytes { (cBuffer: UnsafeMutableRawBufferPointer) -> Int32 in
+                let cPointer = UnsafePointer(cBuffer.baseAddress!.bindMemory(to: UInt8.self, capacity: 1))
+                return additional.withUnsafeMutableReadableBytes { (adBuffer: UnsafeMutableRawBufferPointer) -> Int32 in
+                    let adPointer = UnsafePointer(adBuffer.baseAddress!.bindMemory(to: UInt8.self, capacity: 1))
+                    return nonce.withUnsafeBytes { (npub: UnsafePointer<UInt8>) -> Int32 in
+                        key.withUnsafeBytes { (k: UnsafePointer<UInt8>) -> Int32 in
+                            crypto_aead_chacha20poly1305_ietf_decrypt(mPointer, messageLength, nil, cPointer, cipherLength, adPointer, additionalLength, npub, k)
+                        }
+                    }
+                }
+            }
+        }
+        guard result == 0 else {
+            throw Error.couldNotDecrypt
+        }
+        message.moveWriterIndex(forwardBy: Int(messageLength.pointee))
+    }
+}
+extension HAPCrypto {
+    internal static func SD_public(secretKey: Data) -> Data? {
+        return crypto(crypto_scalarmult_curve25519_base,
+                      Data(count: Int(crypto_scalarmult_curve25519_BYTES)),
+                      secretKey)
+    }
+    internal static func SD_sharedSecret(_ secretKey: Data, otherPublicKey: Data) -> HAPSharedSecret? {
+        return crypto(crypto_scalarmult,
+                      Data(count: Int(crypto_scalarmult_BYTES)),
+                      secretKey,
+                      otherPublicKey)
+    }
+}
+#else
+extension HAPCrypto {
+    static func SD_verify(publicKey: Data, message: Data, signature: Data) throws {
+        assertionFailure("libsodium unavailable")
+    }
+
+    static func SD_sign(privateKey: Data, message: Data) throws -> Data {
+        assertionFailure("libsodium unavailable")
+        return Data()
+    }
+
+    static func SD_generateSignKeypair() -> (publicKey: Data, privateKey: Data) {
+        assertionFailure("libsodium unavailable")
+        return (Data(), Data())
+    }
+}
+extension HAPCrypto {
+
+    internal static func SD_encrypt(message: Data, additional: Data = Data(), nonce: Data, key: Data) throws -> Data {
+        assertionFailure("libsodium unavailable")
+        return Data()
+    }
+
+    internal static func SD_encrypt(message: inout ByteBuffer, additional: ByteBufferView, nonce: Data, key: Data, cipher: inout ByteBuffer) throws {
+        assertionFailure("libsodium unavailable")
+    }
+
+    internal static func SD_decrypt(cipher: Data, additional: Data = Data(), nonce: Data, key: Data) throws -> Data {
+        assertionFailure("libsodium unavailable")
+        return Data()
+    }
+
+    internal static func SD_decrypt(cipher: inout ByteBuffer, additional: inout ByteBuffer, nonce: Data, key: Data, message: inout ByteBuffer) throws {
+        assertionFailure("libsodium unavailable")
+    }
+}
+extension HAPCrypto {
+    internal static func SD_public(secretKey: Data) -> Data? {
+        assertionFailure("libsodium unavailable")
+        return nil
+    }
+    internal static func SD_sharedSecret(_ secretKey: Data, otherPublicKey: Data) -> HAPSharedSecret? {
+        assertionFailure("libsodium unavailable")
+        return nil
+    }
+}
+#endif

--- a/Sources/HAP/Security/HAPCrypto.swift
+++ b/Sources/HAP/Security/HAPCrypto.swift
@@ -1,0 +1,238 @@
+import Cryptor
+import Foundation
+import NIO
+import func HKDF.deriveKey
+
+/* 
+
+ protocol HAPSharedSecret {
+     func base64EncodedString() -> String
+     var hex: String { get }
+ }
+ protocol HAPSymmetricKey {
+     var data: Data { get }
+     var hex: String { get }
+ }
+
+ */
+
+protocol HAPCryptoProtocol {
+    
+    static func verify(publicKey: Data, message: Data, signature: Data) throws
+    static func sign(privateKey: Data, message: Data) throws -> Data
+    static func generateSignKeypair() -> (publicKey: Data, privateKey: Data)
+
+    static func encrypt(message: Data, additional: Data, nonce: Data, key: HAPSymmetricKey) throws -> Data
+    static func decrypt(cipher: Data, additional: Data, nonce: Data, key: HAPSymmetricKey) throws -> Data
+    static func encrypt(message: inout ByteBuffer, additional: ByteBufferView, nonce: Data, key: HAPSymmetricKey, cipher: inout ByteBuffer) throws
+    static func decrypt(cipher: inout ByteBuffer, additional: inout ByteBuffer, nonce: Data, key: HAPSymmetricKey, message: inout ByteBuffer) throws
+
+    static func generateSecret() -> Data?
+    static func `public`(secretKey: Data) -> Data?
+    static func sharedSecret(_ secretKey: Data, otherPublicKey: Data) -> HAPSharedSecret?
+
+}
+
+enum HAPCrypto: HAPCryptoProtocol {
+    enum Error: Swift.Error {
+        case couldNotDecrypt
+        case couldNotEncrypt
+        case invalidSignature
+        case couldNotSign
+
+    }
+
+    internal static func upgradeNonce(_ nonce: Data) -> Data {
+        switch nonce.count {
+        case 12: return nonce
+        case 8: return Data(count: 4) + nonce
+        default: abort()
+        }
+    }
+}
+
+#if canImport(CryptoKit)
+import CryptoKit
+
+extension HAPCrypto {
+
+    @inlinable
+    static func verify(publicKey: Data, message: Data, signature: Data) throws {
+        if #available(macOS 10.15, iOS 13, *) {
+            try CK_verify(publicKey: publicKey, message: message, signature: signature)
+        } else {
+            try SD_verify(publicKey: publicKey, message: message, signature: signature)
+        }
+    }
+
+    @inlinable
+    static func sign(privateKey: Data, message: Data) throws -> Data {
+        if #available(macOS 10.15, iOS 13, *) {
+            return try CK_sign(privateKey: privateKey, message: message)
+        } else {
+            return try SD_sign(privateKey: privateKey, message: message)
+        }
+    }
+
+    @inlinable
+    static func generateSignKeypair() -> (publicKey: Data, privateKey: Data) {
+        if #available(macOS 10.15, iOS 13, *) {
+            return CK_generateSignKeypair()
+        } else {
+            return SD_generateSignKeypair()
+        }
+    }
+}
+extension HAPCrypto {
+
+    @inlinable
+    static func encrypt(message: Data, additional: Data = Data(), nonce: Data, key: HAPSymmetricKey) throws -> Data {
+        if #available(macOS 10.15, iOS 13, *) {
+            return try CK_encrypt(message: message, nonce: nonce, key: symmetricKey(key))
+        }
+        #if os(macOS) && arch(arm64)
+        assertionFailure("libsodium unavailable")
+        return Data()
+        #else
+        return try SD_encrypt(message: message, additional: additional, nonce: nonce, key: key as! Data)
+        #endif
+    }
+
+    @inlinable
+    static func decrypt(cipher: Data, additional: Data = Data(), nonce: Data, key: HAPSymmetricKey) throws -> Data {
+        if #available(macOS 10.15, iOS 13, *) {
+            return try CK_decrypt(cipher: cipher, nonce: nonce, key: symmetricKey(key))
+        }
+        #if os(macOS) && arch(arm64)
+        assertionFailure("libsodium unavailable")
+        return Data()
+        #else
+        return try SD_decrypt(cipher: cipher, additional: additional, nonce: nonce, key: key as! Data)
+        #endif
+    }
+
+    @inlinable
+    static func encrypt(message: inout ByteBuffer, additional: ByteBufferView, nonce: Data, key: HAPSymmetricKey, cipher: inout ByteBuffer) throws {
+        if #available(macOS 10.15, iOS 13, *) {
+            try CK_encrypt(message: &message, additional: additional, nonce: nonce, key: symmetricKey(key), cipher: &cipher)
+            return
+        }
+        #if os(macOS) && arch(arm64)
+            assertionFailure("libsodium unavailable")
+        #else
+        try SD_encrypt(message: &message, additional: additional, nonce: nonce, key: key as! Data, cipher: &cipher)
+        #endif
+    }
+
+    @inlinable
+    static func decrypt(cipher: inout ByteBuffer, additional: inout ByteBuffer, nonce: Data, key: HAPSymmetricKey, message: inout ByteBuffer) throws {
+
+        if #available(macOS 10.15, iOS 13, *) {
+            try CK_decrypt(cipher: &cipher, additional: &additional, nonce: nonce, key: symmetricKey(key), message: &message)
+            return
+        }
+        #if os(macOS) && arch(arm64)
+            assertionFailure("libsodium unavailable")
+        #else
+        try SD_decrypt(cipher: &cipher, additional: &additional, nonce: nonce, key: key as! Data, message: &message)
+        #endif
+    }
+
+    @available(macOS 10.15, iOS 13, *)
+    private static func symmetricKey(_ key: HAPSymmetricKey) -> SymmetricKey {
+        if let symmetricKey = key as? SymmetricKey {
+            return symmetricKey
+        } else {
+            return SymmetricKey(data: key as! Data)
+        }
+    }
+}
+extension HAPCrypto {
+    @inlinable
+    static func generateSecret() -> Data? {
+        if #available(macOS 10.15, iOS 13, *) {
+            return Curve25519.KeyAgreement.PrivateKey().rawRepresentation
+        } else {
+            return (try? Random.generate(byteCount: 32)).flatMap({ Data($0) })
+        }
+    }
+
+    @inlinable
+    static func `public`(secretKey: Data) -> Data? {
+        if #available(macOS 10.15, iOS 13, *) {
+            return CK_public(secretKey: secretKey)
+        }
+        return SD_public(secretKey: secretKey)
+    }
+
+    @inlinable
+    static func sharedSecret(_ secretKey: Data, otherPublicKey: Data) -> HAPSharedSecret? {
+        if #available(macOS 10.15, iOS 13, *) {
+            return CK_sharedSecret(secretKey, otherPublicKey: otherPublicKey)
+        }
+        return SD_sharedSecret(secretKey, otherPublicKey: otherPublicKey)
+    }
+
+    @inlinable
+    static func deriveSha512(
+        seed: HAPSharedSecret,
+        info: Data,
+        salt: Data,
+        count: Int) -> HAPSymmetricKey {
+        if #available(macOS 10.15, iOS 13, *) {
+            if let sharedSecret = seed as? SharedSecret {
+                return sharedSecret.hkdfDerivedSymmetricKey(
+                    using: SHA512.self,
+                    salt: salt,
+                    sharedInfo: info,
+                    outputByteCount: count)
+            }
+        }
+
+        return deriveKey(algorithm: .sha512, seed: seed as! Data, info: info, salt: salt, count: count)
+    }
+}
+#else // No CryptoKit
+extension HAPCrypto {
+
+    @inlinable
+    static func verify(publicKey: Data, message: Data, signature: Data) throws {
+        try SD_verify(publicKey: publicKey, message: message, signature: signature)
+    }
+
+    @inlinable
+    static func sign(privateKey: Data, message: Data) throws -> Data {
+        return try SD_sign(privateKey: privateKey, message: message)
+    }
+
+    @inlinable
+    static func generateSignKeypair() -> (publicKey: Data, privateKey: Data) {
+        return SD_generateSignKeypair()
+    }
+}
+extension HAPCrypto {
+    @inlinable
+    static func generateSecret() -> Data? {
+        return (try? Random.generate(byteCount: 32)).flatMap({ Data($0) })
+    }
+
+    @inlinable
+    static func `public`(secretKey: Data) -> Data? {
+        return SD_public(secretKey: secretKey)
+    }
+
+    @inlinable
+    static func sharedSecret(_ secretKey: Data, otherPublicKey: Data) -> HAPSharedSecret? {
+        return SD_sharedSecret(secretKey, otherPublicKey: otherPublicKey)
+    }
+
+    @inlinable
+    static func deriveSha512(
+        seed: HAPSharedSecret,
+        info: Data,
+        salt: Data,
+        count: Int) -> HAPSymmetricKey {
+        return deriveKey(algorithm: .sha512, seed: seed as! Data, info: info, salt: salt, count: count)
+    }
+}
+#endif

--- a/Sources/HAP/Security/HAPCrypto.swift
+++ b/Sources/HAP/Security/HAPCrypto.swift
@@ -49,6 +49,15 @@ enum HAPCrypto: HAPCryptoProtocol {
         default: abort()
         }
     }
+
+    @inlinable
+    static func sharedSecret(stringEncoded: String) -> HAPSharedSecret? {
+        let data = Data(base64Encoded: stringEncoded)
+        let secretKey = data!.prefix(32)
+        let otherPublicKey = data!.suffix(32)
+        return Keys.sharedSecret(secretKey, otherPublicKey: otherPublicKey)
+    }
+
 }
 
 #if canImport(CryptoKit)

--- a/Sources/HAP/Security/Keys.swift
+++ b/Sources/HAP/Security/Keys.swift
@@ -1,0 +1,156 @@
+// swiftlint:disable no_grouping_extension implicit_return force_cast
+
+import Cryptor
+import Foundation
+import func HKDF.deriveKey
+
+#if !(os(macOS) && arch(arm64))
+import CLibSodium
+#endif
+
+protocol HAPSharedSecret {
+    func base64EncodedString() -> String
+    var hex: String { get }
+}
+protocol HAPSymmetricKey {
+    var data: Data { get }
+    var hex: String { get }
+}
+
+extension Data: HAPSharedSecret, HAPSymmetricKey {
+
+    @inlinable var data: Data {
+        return self
+    }
+
+    @inlinable func base64EncodedString() -> String {
+        self.base64EncodedString(options: [])
+    }
+    public var hex: String {
+        return self.reduce("") { $0 + String(format: "%02x", $1) }
+    }
+}
+
+#if canImport(CryptoKit)
+
+import CryptoKit
+
+@available(macOS 10.15, iOS 13, *)
+extension SharedSecret: HAPSharedSecret {
+    var data: Data {
+        return withUnsafeBytes {
+            return Data($0)
+        }
+    }
+    func base64EncodedString() -> String {
+        return data.base64EncodedString()
+    }
+    public var hex: String {
+        return data.hex
+    }
+}
+
+@available(macOS 10.15, iOS 13, *)
+extension SymmetricKey: HAPSymmetricKey {
+    var data: Data {
+        return withUnsafeBytes {
+            return Data($0)
+        }
+    }
+    public var hex: String {
+        return data.hex
+    }
+}
+
+#endif
+
+enum Keys {
+    static func generateSecret() -> Data? {
+        if #available(macOS 10.15, iOS 13, *) {
+            return Curve25519.KeyAgreement.PrivateKey().rawRepresentation
+        } else {
+            return (try? Random.generate(byteCount: 32)).flatMap({ Data(bytes: $0) })
+        }
+    }
+    static func `public`(secretKey: Data) -> Data? {
+        if #available(macOS 10.15, iOS 13, *) {
+            return CK_public(secretKey: secretKey)
+        }
+        return SD_public(secretKey: secretKey)
+    }
+    static func sharedSecret(_ secretKey: Data, otherPublicKey: Data) -> HAPSharedSecret? {
+
+        if #available(macOS 10.15, iOS 13, *) {
+            return CK_sharedSecret(secretKey, otherPublicKey: otherPublicKey)
+        }
+        return SD_sharedSecret(secretKey, otherPublicKey: otherPublicKey)
+    }
+
+    static func deriveSha512(
+        seed: HAPSharedSecret,
+        info: Data,
+        salt: Data,
+        count: Int) -> HAPSymmetricKey {
+        if #available(macOS 10.15, iOS 13, *) {
+            if let sharedSecret = seed as? SharedSecret {
+                return sharedSecret.hkdfDerivedSymmetricKey(
+                    using: SHA512.self,
+                    salt: salt,
+                    sharedInfo: info,
+                    outputByteCount: count)
+            }
+        }
+
+        return deriveKey(algorithm: .sha512, seed: seed as! Data, info: info, salt: salt, count: count)
+    }
+}
+
+#if !(os(macOS) && arch(arm64))
+extension Keys {
+    internal static func SD_public(secretKey: Data) -> Data? {
+        return crypto(crypto_scalarmult_curve25519_base,
+                      Data(count: Int(crypto_scalarmult_curve25519_BYTES)),
+                      secretKey)
+    }
+    internal static func SD_sharedSecret(_ secretKey: Data, otherPublicKey: Data) -> HAPSharedSecret? {
+        return crypto(crypto_scalarmult,
+                      Data(count: Int(crypto_scalarmult_BYTES)),
+                      secretKey,
+                      otherPublicKey)
+    }
+
+}
+#else
+extension Keys {
+    internal static func SD_public(secretKey: Data) -> Data? {
+        assertionFailure("libsodium unavailable")
+        return nil
+    }
+    internal static func SD_sharedSecret(_ secretKey: Data, otherPublicKey: Data) -> HAPSharedSecret? {
+        assertionFailure("libsodium unavailable")
+        return nil
+    }
+}
+
+#endif
+
+@available(macOS 10.15, iOS 13, *)
+extension Keys {
+    internal static func CK_public(secretKey: Data) -> Data? {
+        do {
+            let privateKey = try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: secretKey)
+            return privateKey.publicKey.rawRepresentation
+        } catch {
+            return nil
+        }
+    }
+    internal static func CK_sharedSecret(_ secretKey: Data, otherPublicKey: Data) -> HAPSharedSecret? {
+        do {
+            let sharedPublicKey = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: otherPublicKey)
+            let privateKey = try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: secretKey)
+            return try? privateKey.sharedSecretFromKeyAgreement(with: sharedPublicKey)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Sources/HAP/Security/Keys.swift
+++ b/Sources/HAP/Security/Keys.swift
@@ -20,7 +20,7 @@ extension Data: HAPSharedSecret, HAPSymmetricKey {
     }
 
     @inlinable func base64EncodedString() -> String {
-        self.base64EncodedString(options: [])
+        return self.base64EncodedString(options: [])
     }
     public var hex: String {
         return self.reduce("") { $0 + String(format: "%02x", $1) }

--- a/Sources/HAP/Security/Keys.swift
+++ b/Sources/HAP/Security/Keys.swift
@@ -28,6 +28,13 @@ extension Data: HAPSharedSecret, HAPSymmetricKey {
 }
 
 enum Keys {
+    @inlinable
+    static func sharedSecret(stringEncoded: String) -> HAPSharedSecret? {
+        let data = Data(base64Encoded: stringEncoded)
+        let secretKey = data!.prefix(32)
+        let otherPublicKey = data!.suffix(32)
+        return Keys.sharedSecret(secretKey, otherPublicKey: otherPublicKey)
+    }
 }
 
 #if canImport(CryptoKit)

--- a/Sources/HAP/Security/Keys.swift
+++ b/Sources/HAP/Security/Keys.swift
@@ -69,7 +69,7 @@ enum Keys {
         if #available(macOS 10.15, iOS 13, *) {
             return Curve25519.KeyAgreement.PrivateKey().rawRepresentation
         } else {
-            return (try? Random.generate(byteCount: 32)).flatMap({ Data(bytes: $0) })
+            return (try? Random.generate(byteCount: 32)).flatMap({ Data($0) })
         }
     }
     static func `public`(secretKey: Data) -> Data? {

--- a/Sources/HAP/Server/ChannelHandlers.swift
+++ b/Sources/HAP/Server/ChannelHandlers.swift
@@ -8,7 +8,7 @@ import NIOHTTP1
 fileprivate let logger = Logger(label: "hap.nio")
 
 enum CryptographyEvent {
-    case sharedKey(Data)
+    case sharedKey(HAPSharedSecret)
 }
 
 class CryptographerHandler: ChannelDuplexHandler {
@@ -277,7 +277,7 @@ class UpgradeEventHandler: ChannelOutboundHandler {
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         var response = unwrapOutboundIn(data)
         if let sharedKeyB64 = response.headers["x-shared-key"].first {
-            let sharedKey = Data(base64Encoded: sharedKeyB64)!
+            let sharedKey = Keys.sharedSecret(stringEncoded: sharedKeyB64)!
             response.headers.remove(name: "x-shared-key")
             context.write(wrapOutboundOut(response)).whenSuccess {
                 context.triggerUserOutboundEvent(CryptographyEvent.sharedKey(sharedKey), promise: nil)

--- a/Sources/HAP/Server/Server.swift
+++ b/Sources/HAP/Server/Server.swift
@@ -30,7 +30,8 @@ public class Server: NSObject, NetServiceDelegate {
     /// - Parameters:
     ///   - device: the device to advertise
     ///   - listenPort: (optional) the port to listen on, if 0 a random port will be chosen (default: 0)
-    ///   - worker: (optional) by default a new `MultiThreadedEventLoopGroup` loop is created having the same `numberOfThreads` as the `System.coreCount`, provide your own `EventLoopGroup` for more control
+    ///   - worker: (optional) by default a new `MultiThreadedEventLoopGroup` loop is created having the same
+    ///    `numberOfThreads` as the `System.coreCount`, provide your own `EventLoopGroup` for more control
     public init(
         device: Device,
         listenPort requestedPort: Int = 0,

--- a/Sources/HAP/Utils/TLV8.swift
+++ b/Sources/HAP/Utils/TLV8.swift
@@ -70,9 +70,9 @@ func decode<Key>(_ data: Data) throws -> [(Key, Data)] where Key: RawRepresentab
                 result.append((currentType, currentValue))
             }
             currentType = type
-            currentValue = Data(bytes: Array(value))
+            currentValue = Data(Array(value))
         } else {
-            currentValue! += Data(bytes: Array(value))
+            currentValue! += Data(Array(value))
         }
 
         index = endIndex
@@ -86,7 +86,7 @@ func decode<Key>(_ data: Data) throws -> [(Key, Data)] where Key: RawRepresentab
 func encode<Key>(_ array: [(Key, Data)]) -> Data where Key: RawRepresentable, Key.RawValue == UInt8 {
     var result = Data()
     func append(type: UInt8, value: Data.SubSequence) {
-        result.append(Data(bytes: [type, UInt8(value.count)] + value))
+        result.append(Data([type, UInt8(value.count)] + value))
     }
 
     for (type, value) in array {

--- a/Tests/HAPTests/CryptoKitTests.swift
+++ b/Tests/HAPTests/CryptoKitTests.swift
@@ -1,0 +1,336 @@
+// swiftlint:disable identifier_name force_cast function_body_length type_body_length line_length force_try
+#if canImport(CryptoKit)
+import CryptoKit
+import Cryptor
+@testable import HAP
+import HKDF
+import SRP
+import XCTest
+
+@available(macOS 10.15, *)
+class CryptoKitTests: XCTestCase {
+
+    let mySecret = Data(hex: "e0c0fa3b7da99fc893adc83feef61a0a7f529fe083a889f7ff404f73182bce59")!
+    let myPublic = Data(hex: "c67ae350f5b3cca448837d7b7113a48c15da9be235fb2146dd48c1620e198832")!
+    let otherSecret = Data(hex: "3f3465028bfd4288539ca19368168700953f219b989254882d07924abfda0949")!
+    let otherPublic = Data(hex: "2c75efb94b3d96954d20dac6cc107cd78a703a022d55927c6728f1255ed39547")!
+    let encryptionKey = Data(hex: "fc47f33641dba5cc153aef27b8fe45b3c2e674f346468eaf06e53fa9544f4a87")!
+    let sharedSecret = Data(hex: "a7676523ea9deff107987d51f7bb5c0c6289554b11e89f3901d05507df2c4827")!
+    let cipher = Data(hex: "9818bd6064b0a7a99ef8f054e1567af19d2cd7daf1cdfa58458bb4")!
+    let username = "hubba hubba"
+
+    func testGenerateSecret() {
+        guard let secret = Keys.generateSecret() else {
+            XCTFail("Unable to generate Secret")
+            return
+        }
+        print(secret.hex)
+        XCTAssertEqual(secret.count, 32, "Secret is not 256 bits long")
+    }
+
+    func testPublic() {
+        let sd = Keys.SD_public(secretKey: mySecret)
+        XCTAssertEqual(myPublic.hex, sd?.hex, "Public key does not match")
+    }
+
+    func testSharedSecret() {
+        let ck = Keys.CK_sharedSecret(mySecret, otherPublicKey: otherPublic)
+        XCTAssertEqual(ck?.hex, sharedSecret.hex, "Shared secret did not match")
+    }
+
+    func testDeriveSha512() {
+        guard let ckSharedSecret = Keys.sharedSecret(mySecret, otherPublicKey: otherPublic) else {
+            return XCTFail("CryptoKit Unable to create shared secret")
+        }
+        let info = "Pair-Verify-Encrypt-Info".data(using: .utf8)!
+        let salt = "Pair-Verify-Encrypt-Salt".data(using: .utf8)!
+
+        let ck = Keys.deriveSha512(seed: ckSharedSecret,
+                                   info: info,
+                                   salt: salt,
+                                   count: 32)
+
+        let hkdf = HKDF.deriveKey(algorithm: .sha512, seed: sharedSecret, info: info, salt: salt, count: 32)
+
+        XCTAssertEqual(ck.hex, hkdf.hex, "Encryption Key did not match")
+    }
+
+    func testEncrypt() {
+        let nonce = "PV-Msg02".data(using: .utf8)!
+
+        let symKey = SymmetricKey(data: encryptionKey)
+        guard let ckCipher = try? ChaCha20Poly1305.CK_encrypt(message: username.data(using: .utf8)!,
+                                                              nonce: nonce,
+                                                              key: symKey) else {
+            return XCTFail("CryptoKit Couldn't encrypt")
+        }
+        XCTAssertEqual(cipher.hex, ckCipher.hex, "Encoding does not match")
+    }
+
+    func testDecrypt() {
+        let nonce = "PV-Msg02".data(using: .utf8)!
+
+        let info = "Pair-Verify-Encrypt-Info".data(using: .utf8)!
+        let salt = "Pair-Verify-Encrypt-Salt".data(using: .utf8)!
+
+        let sharedSecret = Keys.sharedSecret(otherSecret, otherPublicKey: myPublic)!
+
+        let key = Keys.deriveSha512(seed: sharedSecret,
+                                    info: info,
+                                    salt: salt,
+                                    count: 32)
+
+        let decryptKey = key as! SymmetricKey
+        guard let message = try? ChaCha20Poly1305.CK_decrypt(cipher: cipher,
+                                                             nonce: nonce,
+                                                             key: decryptKey) else {
+            return XCTFail("CryptoKit Couldn't decrypt")
+        }
+
+        XCTAssertEqual(String(data: message, encoding: .utf8), username)
+    }
+
+    func testSign() {
+        let keys = Ed25519.CK_generateSignKeypair() // these are the client's keys
+        let buffer = Data(hex: "0d0086707542af59d8a62123455257e9f45b349501f46cad0e5f6ded6aab98")!
+
+        let xs = try! Ed25519.CK_sign(privateKey: keys.privateKey, message: buffer)
+        let verified: Bool
+         do {
+             try Ed25519.CK_verify(publicKey: keys.publicKey, message: buffer, signature: xs)
+             verified = true
+         } catch {
+             verified = false
+         }
+         XCTAssertTrue(verified, "CryptoKit not verified Signature")
+    }
+
+    func testCreateAuthenticator() {
+        let setupCode = "123-44-321"
+
+        let username = "Pair-Setup"
+        let testSalt = "b1bd375e4dd1bf8aabf06466c441053a".data(using: .utf8)!
+
+        let t0 = Date()
+        let (salt, verificationKey) = Authenticator.createSaltedVerificationKey(username: username,
+                                                                                password: setupCode,
+                                                                                salt: testSalt)
+        let t1 = Date()
+        _ = Authenticator(username: username, salt: salt, verificationKey: verificationKey)
+
+        let t2 = Date()
+
+        // Display timing
+        print("create: \(-t1.distance(to: t0))")
+        print("session: \(-t2.distance(to: t1))")
+    }
+
+    func testSRP() {
+        let setupCode = "123-44-321"
+        let group = Group.N3072
+        let algorithm = Digest.Algorithm.sha512
+        let username = "Pair-Setup"
+
+        print("Start Authentication")
+
+        let t0 = Date()
+
+        let (salt, verificationKey) = createSaltedVerificationKey(username: username,
+                                                                  password: setupCode,
+                                                                  group: group,
+                                                                  algorithm: algorithm)
+        // HAP: Start Response M2
+        let t1 = Date()
+
+        let session = Authenticator(username: username,
+                                    salt: salt,
+                                    verificationKey: verificationKey)
+
+        let t2 = Date()
+        print("create: \(-t1.distance(to: t0))") // 5.2s, 5.0
+        print("session: \(-t2.distance(to: t1))") // 10.5s, 9.7
+
+        let (_, serverPublicKey) = session.getChallenge()
+
+        // iOS: verify request M3
+
+        print("Step M3")
+        let iOSClient = SRP.Client(username: username, password: setupCode, group: group, algorithm: algorithm)
+        let (_, clientPublicKey) = iOSClient.startAuthentication()
+
+        let clientKeyProof = try! iOSClient.processChallenge(salt: salt,
+                                                             publicKey: serverPublicKey)
+
+        // HAP: Verify Response M4
+        print("Step M4")
+
+        let serverKeyProof = try! session.verifySession(publicKey: clientPublicKey,
+                                                        keyProof: clientKeyProof)
+
+        // iOS: verify
+        print("Step M4 verify")
+
+        do {
+            try iOSClient.verifySession(keyProof: serverKeyProof)
+        } catch {
+            return XCTFail("Client verification failed")
+        }
+
+        // iOS: Request Generation M5
+        // "b1cbb675e216321c31135b2b37fe8f321ed11f0a8cb0b634e0cf8a258a69dc4d7324b5a33480e43ac064ce87fdf443f123c352620c1dae1e219557422a5c483a"
+        print("Step M5")
+
+        let clientKeys = Ed25519.generateSignKeypair()
+        let clientIdentifier = "H1:CC:AA:BB:00:88".data(using: .utf8)!
+
+        let hashInM5 = HKDF.deriveKey(algorithm: .sha512,
+                                      seed: session.server.sessionKey!,
+                                      info: "Pair-Setup-Controller-Sign-Info".data(using: .utf8),
+                                      salt: "Pair-Setup-Controller-Sign-Salt".data(using: .utf8),
+                                      count: 32) +
+            clientIdentifier +
+            clientKeys.publicKey
+
+        let signature = try! Ed25519.sign(privateKey: clientKeys.privateKey, message: hashInM5)
+
+        let request: PairTagTLV8 = [
+            (.publicKey, clientKeys.publicKey),
+            (.identifier, clientIdentifier),
+            (.signature, signature)
+        ]
+
+        let clientEncryptionKey = HKDF.deriveKey(algorithm: .sha512,
+                                                 seed: session.server.sessionKey!,
+                                                 info: "Pair-Setup-Encrypt-Info".data(using: .utf8),
+                                                 salt: "Pair-Setup-Encrypt-Salt".data(using: .utf8),
+                                                 count: 32)
+
+        let encryptedData = try! ChaCha20Poly1305.encrypt(message: encode(request),
+                                                          nonce: "PS-Msg05".data(using: .utf8)!,
+                                                          key: clientEncryptionKey)
+
+        // HAP: M5 verification, M6 response
+        print("Step M5-M6")
+
+        guard let plaintext = session.decrypt(encryptedData: encryptedData, nonce: "PS-Msg05") else {
+            return XCTFail("Message decryption failed")
+        }
+
+        guard let data: PairTagTLV8 = try? decode(plaintext) else {
+            return XCTFail("Message decode failed")
+        }
+
+        guard let resultPublicKey = data[.publicKey],
+            let resultIdentifier = data[.identifier],
+            let resultSignatureIn = data[.signature]
+            else {
+                return XCTFail("Message extraction failed")
+        }
+
+        print("Client ID \(String(data: resultIdentifier, encoding: .utf8)!)")
+
+        let accessoryIdentifier = "88:00:88:BB:00:BB"
+
+        let sig = session.verifyID(username: resultIdentifier,
+                                   publicKey: resultPublicKey,
+                                   signatureIn: resultSignatureIn,
+                                   deviceID: accessoryIdentifier,
+                                   devicePublicKey: clientKeys.publicKey,
+                                   devicePrivateKey: clientKeys.privateKey)
+
+        guard let signatureOut = sig else {
+            return XCTFail("Unable to verify response or sign key exchange response")
+        }
+
+        let resultInner: PairTagTLV8 = [
+            (.identifier, accessoryIdentifier.data(using: .utf8)!),
+            (.publicKey, clientKeys.publicKey),
+            (.signature, signatureOut)
+        ]
+
+        guard let encryptedResponse = session.encrypt(message: encode(resultInner), nonce: "PS-Msg06") else {
+                return XCTFail("Encrypt key response failed")
+        }
+
+        // iOS: M6 verify
+
+        print("Step M6 verify")
+
+        let verifyText = try! ChaCha20Poly1305.decrypt(cipher: encryptedResponse,
+                                                       nonce: "PS-Msg06".data(using: .utf8)!,
+                                                       key: clientEncryptionKey)
+        let response: PairTagTLV8 = try! decode(verifyText)
+        let hashVerify = HKDF.deriveKey(algorithm: .sha512,
+                                        seed: session.server.sessionKey!,
+                                        info: "Pair-Setup-Accessory-Sign-Info".data(using: .utf8),
+                                        salt: "Pair-Setup-Accessory-Sign-Salt".data(using: .utf8),
+                                        count: 32) +
+            response[.identifier]! +
+            response[.publicKey]!
+        do {
+            try Ed25519.verify(publicKey: response[.publicKey]!, message: hashVerify, signature: response[.signature]!)
+        } catch {
+            return XCTFail("Client verification failed")
+        }
+
+        XCTAssertEqual(response[.publicKey]!.hex, clientKeys.publicKey.hex)
+    }
+
+    func testCrypt() {
+
+        let sessionKey = Data(hex: "b1cbb675e216321c31135b2b37fe8f321ed11f0a8cb0b634e0cf8a258a69dc4d7324b5a33480e43ac064ce87fdf443f123c352620c1dae1e219557422a5c483a")!
+
+        let clientKeys = Ed25519.generateSignKeypair()
+        let clientIdentifier = "H1:CC:AA:BB:00:88".data(using: .utf8)!
+
+        let hashInM5 = HKDF.deriveKey(algorithm: .sha512,
+                                      seed: sessionKey,
+                                      info: "Pair-Setup-Controller-Sign-Info".data(using: .utf8),
+                                      salt: "Pair-Setup-Controller-Sign-Salt".data(using: .utf8),
+                                      count: 32) +
+            clientIdentifier +
+            clientKeys.publicKey
+
+        let signature = try! Ed25519.sign(privateKey: clientKeys.privateKey, message: hashInM5)
+
+        let request: PairTagTLV8 = [
+            (.publicKey, clientKeys.publicKey),
+            (.identifier, clientIdentifier),
+            (.signature, signature)
+        ]
+
+        let clientEncryptionKey = HKDF.deriveKey(algorithm: .sha512,
+                                                 seed: sessionKey,
+                                                 info: "Pair-Setup-Encrypt-Info".data(using: .utf8),
+                                                 salt: "Pair-Setup-Encrypt-Salt".data(using: .utf8),
+                                                 count: 32)
+
+        let eKey = SymmetricKey(data: clientEncryptionKey)
+        let encryptedData = try! ChaCha20Poly1305.CK_encrypt(message: encode(request),
+                                                             nonce: "PS-Msg05".data(using: .utf8)!,
+                                                             key: eKey)
+
+        let xKey = eKey
+        guard let plaintext = try? ChaCha20Poly1305.CK_decrypt(cipher: encryptedData,
+                                                               nonce: "PS-Msg05".data(using: .utf8)!,
+                                                               key: xKey) else {
+                                                                return XCTFail("Message decryption failed")
+        }
+
+        guard let data: PairTagTLV8 = try? decode(plaintext) else {
+            return XCTFail("Message decode failed")
+        }
+
+        guard let resultPublicKey = data[.publicKey],
+            let resultIdentifier = data[.identifier],
+            let resultSignatureIn = data[.signature]
+            else {
+                return XCTFail("Message extraction failed")
+        }
+
+        XCTAssertTrue(resultPublicKey.hex == clientKeys.publicKey.hex, "CryptoKit not matching Signature")
+        XCTAssertTrue(resultIdentifier.hex == clientIdentifier.hex, "CryptoKit not matching Signature")
+        XCTAssertTrue(resultSignatureIn.hex == signature.hex, "CryptoKit not matching Signature")
+    }
+}
+#endif

--- a/Tests/HAPTests/CryptoKitTests.swift
+++ b/Tests/HAPTests/CryptoKitTests.swift
@@ -3,7 +3,7 @@
 import CryptoKit
 import Cryptor
 @testable import HAP
-import HKDF
+import func HKDF.deriveKey
 import SRP
 import XCTest
 
@@ -50,7 +50,7 @@ class CryptoKitTests: XCTestCase {
                                    salt: salt,
                                    count: 32)
 
-        let hkdf = HKDF.deriveKey(algorithm: .sha512, seed: sharedSecret, info: info, salt: salt, count: 32)
+        let hkdf = deriveKey(algorithm: .sha512, seed: sharedSecret, info: info, salt: salt, count: 32)
 
         XCTAssertEqual(ck.hex, hkdf.hex, "Encryption Key did not match")
     }
@@ -183,7 +183,7 @@ class CryptoKitTests: XCTestCase {
         let clientKeys = Ed25519.generateSignKeypair()
         let clientIdentifier = "H1:CC:AA:BB:00:88".data(using: .utf8)!
 
-        let hashInM5 = HKDF.deriveKey(algorithm: .sha512,
+        let hashInM5 = deriveKey(algorithm: .sha512,
                                       seed: session.server.sessionKey!,
                                       info: "Pair-Setup-Controller-Sign-Info".data(using: .utf8),
                                       salt: "Pair-Setup-Controller-Sign-Salt".data(using: .utf8),
@@ -199,7 +199,7 @@ class CryptoKitTests: XCTestCase {
             (.signature, signature)
         ]
 
-        let clientEncryptionKey = HKDF.deriveKey(algorithm: .sha512,
+        let clientEncryptionKey = deriveKey(algorithm: .sha512,
                                                  seed: session.server.sessionKey!,
                                                  info: "Pair-Setup-Encrypt-Info".data(using: .utf8),
                                                  salt: "Pair-Setup-Encrypt-Salt".data(using: .utf8),
@@ -260,7 +260,7 @@ class CryptoKitTests: XCTestCase {
                                                        nonce: "PS-Msg06".data(using: .utf8)!,
                                                        key: clientEncryptionKey)
         let response: PairTagTLV8 = try! decode(verifyText)
-        let hashVerify = HKDF.deriveKey(algorithm: .sha512,
+        let hashVerify = deriveKey(algorithm: .sha512,
                                         seed: session.server.sessionKey!,
                                         info: "Pair-Setup-Accessory-Sign-Info".data(using: .utf8),
                                         salt: "Pair-Setup-Accessory-Sign-Salt".data(using: .utf8),
@@ -283,7 +283,7 @@ class CryptoKitTests: XCTestCase {
         let clientKeys = Ed25519.generateSignKeypair()
         let clientIdentifier = "H1:CC:AA:BB:00:88".data(using: .utf8)!
 
-        let hashInM5 = HKDF.deriveKey(algorithm: .sha512,
+        let hashInM5 = deriveKey(algorithm: .sha512,
                                       seed: sessionKey,
                                       info: "Pair-Setup-Controller-Sign-Info".data(using: .utf8),
                                       salt: "Pair-Setup-Controller-Sign-Salt".data(using: .utf8),
@@ -299,7 +299,7 @@ class CryptoKitTests: XCTestCase {
             (.signature, signature)
         ]
 
-        let clientEncryptionKey = HKDF.deriveKey(algorithm: .sha512,
+        let clientEncryptionKey = deriveKey(algorithm: .sha512,
                                                  seed: sessionKey,
                                                  info: "Pair-Setup-Encrypt-Info".data(using: .utf8),
                                                  salt: "Pair-Setup-Encrypt-Salt".data(using: .utf8),

--- a/Tests/HAPTests/PairSetupControllerTests.swift
+++ b/Tests/HAPTests/PairSetupControllerTests.swift
@@ -34,7 +34,7 @@ class PairSetupControllerTests: XCTestCase {
         do {
             // Server -> Client: [salt, publicKey]
             let response = try! controller.startRequest([
-                (.pairingMethod, Data(bytes: [PairingMethod.default.rawValue]))
+                (.pairingMethod, Data([PairingMethod.default.rawValue]))
             ], session)
             XCTAssertEqual(response.pairSetupStep, PairSetupStep.startResponse)
             XCTAssertEqual(response[.publicKey], session.server.publicKey)

--- a/Tests/HAPTests/PairVerifyControllerTests.swift
+++ b/Tests/HAPTests/PairVerifyControllerTests.swift
@@ -24,7 +24,7 @@ class PairVerifyControllerTests: XCTestCase {
 
         let controller = PairVerifyController(device: device)
         // these are the client's keys for this verify session
-        let clientSecretKey = try! Data(bytes: Random.generate(byteCount: 32))
+        let clientSecretKey = try! Data(Random.generate(byteCount: 32))
         let clientPublicKey = crypto(crypto_scalarmult_curve25519_base,
                                      Data(count: Int(crypto_scalarmult_curve25519_BYTES)),
                                      clientSecretKey)!
@@ -35,7 +35,7 @@ class PairVerifyControllerTests: XCTestCase {
         do {
             // Client -> Server: public key
             let request: PairTagTLV8 = [
-                (.state, Data(bytes: [PairVerifyStep.startRequest.rawValue])),
+                (.state, Data([PairVerifyStep.startRequest.rawValue])),
                 (.publicKey, clientPublicKey)
             ]
             let resultOuter: PairTagTLV8

--- a/Tests/HAPTests/PairingsEndpointTests.swift
+++ b/Tests/HAPTests/PairingsEndpointTests.swift
@@ -28,8 +28,8 @@ class PairingsEndpointTests: XCTestCase {
     func testListPairingsNonAdmin() {
         setupPairingWithRole(.regularUser)
         let request = [
-            (PairTag.state, Data(bytes: [PairStep.request.rawValue])),
-            (PairTag.pairingMethod, Data(bytes: [PairingMethod.listPairings.rawValue]))
+            (PairTag.state, Data([PairStep.request.rawValue])),
+            (PairTag.pairingMethod, Data([PairingMethod.listPairings.rawValue]))
         ]
         let (_, responseBody) = call(request)
         XCTAssertEqual(responseBody?.error, PairError.authenticationFailed)
@@ -38,8 +38,8 @@ class PairingsEndpointTests: XCTestCase {
     func testListPairingsAdmin() {
         setupPairingWithRole(.admin)
         let request = [
-            (PairTag.state, Data(bytes: [PairStep.request.rawValue])),
-            (PairTag.pairingMethod, Data(bytes: [PairingMethod.listPairings.rawValue]))
+            (PairTag.state, Data([PairStep.request.rawValue])),
+            (PairTag.pairingMethod, Data([PairingMethod.listPairings.rawValue]))
         ]
         let (_, responseBody) = call(request)
         XCTAssertEqual(responseBody?.pairStep, PairStep.response)

--- a/Tests/HAPTests/TLV8Tests.swift
+++ b/Tests/HAPTests/TLV8Tests.swift
@@ -1,7 +1,5 @@
 // swiftlint:disable force_try
 @testable import HAP
-import HKDF
-import SRP
 import XCTest
 
 class TLV8Tests: XCTestCase {


### PR DESCRIPTION
This commit drops the requirement for libsodium on platforms where CryptoKit is available (macOS 10.15, iOS 13, *). If For compatibility with earlier versions of macOS or iOS, libsodium is still linked on intel platforms, but it is entirely removed as a dependency on App Silicon.

All of the sodium or SRP dependant code has been moved to the security classes.
HKDF would have been replaced too, except the method used in HAP to pass a shared secret from pairVerify() to the Cryptographer requires it to be encoded and passed through a text header. Unfortunately the CryptoKit SharedSecret can't be encoded and recreated without the privateKey, so I had to use the existing HKDF function instead. If there is a way to pass the SharedSecret object directly to the cryptographer without using text coded headers, that limitation can be removed.

(I fixed the commit history issue with a rebase)